### PR TITLE
WIP: Update label shortcodes

### DIFF
--- a/data/110/880/308/1/1108803081.geojson
+++ b/data/110/880/308/1/1108803081.geojson
@@ -16,6 +16,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "PJ"
+    ],
     "lbl:latitude":35.343946,
     "lbl:longitude":69.743063,
     "mz:hierarchy_label":1,
@@ -242,7 +245,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563287149,
+    "wof:lastmodified":1565634346,
     "wof:name":"Panjsher",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/110/880/308/3/1108803083.geojson
+++ b/data/110/880/308/3/1108803083.geojson
@@ -16,6 +16,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "DK"
+    ],
     "lbl:latitude":33.723313,
     "lbl:longitude":66.09816,
     "mz:hierarchy_label":1,
@@ -269,7 +272,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563287149,
+    "wof:lastmodified":1565634346,
     "wof:name":"Daykundi",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/322/29/85632229.geojson
+++ b/data/856/322/29/85632229.geojson
@@ -15,6 +15,9 @@
     "itu:country_code":[
         "93"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "AF"
+    ],
     "lbl:latitude":34.159326,
     "lbl:longitude":66.51551,
     "mps:latitude":34.159326,
@@ -1135,9 +1138,6 @@
         }
     ],
     "wof:id":85632229,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -1149,7 +1149,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285379,
+    "wof:lastmodified":1565634336,
     "wof:name":"Afghanistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/674/93/85667493.geojson
+++ b/data/856/674/93/85667493.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "BG"
+    ],
     "lbl:latitude":35.143909,
     "lbl:longitude":63.618063,
     "mps:latitude":35.097324,
@@ -368,9 +371,6 @@
         }
     ],
     "wof:id":85667493,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -382,7 +382,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285372,
+    "wof:lastmodified":1565634336,
     "wof:name":"Badghis",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/674/97/85667497.geojson
+++ b/data/856/674/97/85667497.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "HR"
+    ],
     "lbl:latitude":34.356867,
     "lbl:longitude":61.934317,
     "mps:latitude":34.34941,
@@ -366,9 +369,6 @@
         }
     ],
     "wof:id":85667497,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -380,7 +380,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285374,
+    "wof:lastmodified":1565634336,
     "wof:name":"Hirat",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/03/85667503.geojson
+++ b/data/856/675/03/85667503.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "BM"
+    ],
     "lbl:latitude":35.021332,
     "lbl:longitude":67.232018,
     "mps:latitude":35.039494,
@@ -371,9 +374,6 @@
         }
     ],
     "wof:id":85667503,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -385,7 +385,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285347,
+    "wof:lastmodified":1565634332,
     "wof:name":"Bamyan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/05/85667505.geojson
+++ b/data/856/675/05/85667505.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "BAL"
+    ],
     "lbl:latitude":36.732266,
     "lbl:longitude":66.982671,
     "mps:latitude":36.786669,
@@ -365,9 +368,6 @@
         }
     ],
     "wof:id":85667505,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -379,7 +379,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285350,
+    "wof:lastmodified":1565634332,
     "wof:name":"Balkh",
     "wof:parent_id":85632229,
     "wof:placetype":"region",
@@ -388,6 +388,7 @@
     "wof:population":1073000,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-af",
+    "wof:shortcode":"BAL",
     "wof:subdivision":"AF-BAL",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/856/675/09/85667509.geojson
+++ b/data/856/675/09/85667509.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "FB"
+    ],
     "lbl:latitude":35.838536,
     "lbl:longitude":64.714662,
     "mps:latitude":35.822519,
@@ -374,9 +377,6 @@
         }
     ],
     "wof:id":85667509,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -388,7 +388,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285357,
+    "wof:lastmodified":1565634333,
     "wof:name":"Faryab",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/13/85667513.geojson
+++ b/data/856/675/13/85667513.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "JW"
+    ],
     "lbl:latitude":36.940441,
     "lbl:longitude":65.898332,
     "mps:latitude":36.978401,
@@ -356,9 +359,6 @@
         }
     ],
     "wof:id":85667513,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -370,7 +370,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285371,
+    "wof:lastmodified":1565634335,
     "wof:name":"Jawzjan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/19/85667519.geojson
+++ b/data/856/675/19/85667519.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "GR"
+    ],
     "lbl:latitude":33.897959,
     "lbl:longitude":64.757658,
     "mps:latitude":33.977757,
@@ -343,9 +346,6 @@
         }
     ],
     "wof:id":85667519,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -357,7 +357,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285354,
+    "wof:lastmodified":1565634333,
     "wof:name":"Ghor",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/23/85667523.geojson
+++ b/data/856/675/23/85667523.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "SP"
+    ],
     "lbl:latitude":35.69495,
     "lbl:longitude":66.143867,
     "mps:latitude":35.754422,
@@ -338,9 +341,6 @@
         }
     ],
     "wof:id":85667523,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -352,7 +352,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285367,
+    "wof:lastmodified":1565634335,
     "wof:name":"Sari Pul",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/27/85667527.geojson
+++ b/data/856/675/27/85667527.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "FH"
+    ],
     "lbl:latitude":32.511368,
     "lbl:longitude":62.338331,
     "mps:latitude":32.339969,
@@ -350,9 +353,6 @@
         }
     ],
     "wof:id":85667527,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -364,7 +364,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285351,
+    "wof:lastmodified":1565634332,
     "wof:name":"Farah",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/31/85667531.geojson
+++ b/data/856/675/31/85667531.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "HM"
+    ],
     "lbl:latitude":31.123807,
     "lbl:longitude":64.010782,
     "mps:latitude":31.116802,
@@ -378,9 +381,6 @@
         }
     ],
     "wof:id":85667531,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -392,7 +392,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285358,
+    "wof:lastmodified":1565634334,
     "wof:name":"Hilmand",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/37/85667537.geojson
+++ b/data/856/675/37/85667537.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NM"
+    ],
     "lbl:latitude":30.78658,
     "lbl:longitude":62.434335,
     "mps:latitude":30.796121,
@@ -356,9 +359,6 @@
         }
     ],
     "wof:id":85667537,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -370,7 +370,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285361,
+    "wof:lastmodified":1565634334,
     "wof:name":"Nimroz",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/41/85667541.geojson
+++ b/data/856/675/41/85667541.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "OZ"
+    ],
     "lbl:latitude":32.850353,
     "lbl:longitude":66.197348,
     "mps:latitude":32.767873,
@@ -375,9 +378,6 @@
         }
     ],
     "wof:id":85667541,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -389,7 +389,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285365,
+    "wof:lastmodified":1565634335,
     "wof:name":"Uruzgan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/49/85667549.geojson
+++ b/data/856/675/49/85667549.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "KD"
+    ],
     "lbl:latitude":31.122692,
     "lbl:longitude":65.576028,
     "mps:latitude":31.096615,
@@ -350,9 +353,6 @@
         }
     ],
     "wof:id":85667549,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -364,7 +364,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285370,
+    "wof:lastmodified":1565634335,
     "wof:name":"Kandahar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/55/85667555.geojson
+++ b/data/856/675/55/85667555.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "ZB"
+    ],
     "lbl:latitude":32.26785,
     "lbl:longitude":67.083469,
     "mps:latitude":32.281861,
@@ -357,9 +360,6 @@
         }
     ],
     "wof:id":85667555,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -371,7 +371,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285362,
+    "wof:lastmodified":1565634334,
     "wof:name":"Zabul",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/61/85667561.geojson
+++ b/data/856/675/61/85667561.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "GZ"
+    ],
     "lbl:latitude":33.379194,
     "lbl:longitude":67.792641,
     "mps:latitude":33.419166,
@@ -356,9 +359,6 @@
         }
     ],
     "wof:id":85667561,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -370,7 +370,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285344,
+    "wof:lastmodified":1565634332,
     "wof:name":"Ghazni",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/63/85667563.geojson
+++ b/data/856/675/63/85667563.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "KT"
+    ],
     "lbl:latitude":33.349518,
     "lbl:longitude":69.824158,
     "mps:latitude":33.344982,
@@ -355,9 +358,6 @@
         }
     ],
     "wof:id":85667563,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -369,7 +369,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285364,
+    "wof:lastmodified":1565634334,
     "wof:name":"Khost",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/67/85667567.geojson
+++ b/data/856/675/67/85667567.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "PK"
+    ],
     "lbl:latitude":32.428256,
     "lbl:longitude":68.6846,
     "mps:latitude":32.379678,
@@ -329,9 +332,6 @@
         }
     ],
     "wof:id":85667567,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -343,7 +343,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285348,
+    "wof:lastmodified":1565634332,
     "wof:name":"Paktika",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/73/85667573.geojson
+++ b/data/856/675/73/85667573.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "BD"
+    ],
     "lbl:latitude":36.854525,
     "lbl:longitude":70.807534,
     "mps:latitude":36.85885,
@@ -377,9 +380,6 @@
         }
     ],
     "wof:id":85667573,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -391,7 +391,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285353,
+    "wof:lastmodified":1565634333,
     "wof:name":"Badakhshan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/77/85667577.geojson
+++ b/data/856/675/77/85667577.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NR"
+    ],
     "lbl:latitude":35.229321,
     "lbl:longitude":70.421238,
     "mps:latitude":35.222422,
@@ -367,9 +370,6 @@
         }
     ],
     "wof:id":85667577,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -381,7 +381,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285366,
+    "wof:lastmodified":1565634335,
     "wof:name":"Nuristan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/81/85667581.geojson
+++ b/data/856/675/81/85667581.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "KR"
+    ],
     "lbl:latitude":34.875746,
     "lbl:longitude":70.993766,
     "mps:latitude":34.869617,
@@ -347,9 +350,6 @@
         }
     ],
     "wof:id":85667581,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -361,7 +361,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285356,
+    "wof:lastmodified":1565634333,
     "wof:name":"Kunar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/85/85667585.geojson
+++ b/data/856/675/85/85667585.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "KZ"
+    ],
     "lbl:latitude":36.884389,
     "lbl:longitude":68.763242,
     "mps:latitude":36.884337,
@@ -379,9 +382,6 @@
         }
     ],
     "wof:id":85667585,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -393,7 +393,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285368,
+    "wof:lastmodified":1565634335,
     "wof:name":"Kunduz",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/91/85667591.geojson
+++ b/data/856/675/91/85667591.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NG"
+    ],
     "lbl:latitude":34.256099,
     "lbl:longitude":70.557169,
     "mps:latitude":34.238726,
@@ -350,9 +353,6 @@
         }
     ],
     "wof:id":85667591,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -364,7 +364,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285360,
+    "wof:lastmodified":1565634334,
     "wof:name":"Nangarhar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/95/85667595.geojson
+++ b/data/856/675/95/85667595.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "TK"
+    ],
     "lbl:latitude":36.708316,
     "lbl:longitude":69.624599,
     "mps:latitude":36.715287,
@@ -347,9 +350,6 @@
         }
     ],
     "wof:id":85667595,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -361,7 +361,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285346,
+    "wof:lastmodified":1565634332,
     "wof:name":"Takhar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/01/85667601.geojson
+++ b/data/856/676/01/85667601.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "BL"
+    ],
     "lbl:latitude":35.850232,
     "lbl:longitude":68.979825,
     "mps:latitude":35.842387,
@@ -353,9 +356,6 @@
         }
     ],
     "wof:id":85667601,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -367,7 +367,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285389,
+    "wof:lastmodified":1565634339,
     "wof:name":"Baghlan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/03/85667603.geojson
+++ b/data/856/676/03/85667603.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "KB"
+    ],
     "lbl:latitude":34.596043,
     "lbl:longitude":69.15119,
     "mps:latitude":34.594741,
@@ -353,9 +356,6 @@
         }
     ],
     "wof:id":85667603,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -367,7 +367,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285382,
+    "wof:lastmodified":1565634338,
     "wof:name":"Kabul",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/09/85667609.geojson
+++ b/data/856/676/09/85667609.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "KP"
+    ],
     "lbl:latitude":35.023295,
     "lbl:longitude":69.654553,
     "mps:latitude":35.020517,
@@ -350,9 +353,6 @@
         }
     ],
     "wof:id":85667609,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -364,7 +364,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285387,
+    "wof:lastmodified":1565634339,
     "wof:name":"Kapisa",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/17/85667617.geojson
+++ b/data/856/676/17/85667617.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "LA"
+    ],
     "lbl:latitude":34.700402,
     "lbl:longitude":70.187189,
     "mps:latitude":34.719993,
@@ -347,9 +350,6 @@
         }
     ],
     "wof:id":85667617,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -361,7 +361,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285386,
+    "wof:lastmodified":1565634339,
     "wof:name":"Laghman",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/23/85667623.geojson
+++ b/data/856/676/23/85667623.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "LW"
+    ],
     "lbl:latitude":34.039909,
     "lbl:longitude":69.159271,
     "mps:latitude":34.041139,
@@ -353,9 +356,6 @@
         }
     ],
     "wof:id":85667623,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -367,7 +367,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285392,
+    "wof:lastmodified":1565634339,
     "wof:name":"Logar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/27/85667627.geojson
+++ b/data/856/676/27/85667627.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "PV"
+    ],
     "lbl:latitude":35.01109,
     "lbl:longitude":68.82569,
     "mps:latitude":35.008722,
@@ -334,9 +337,6 @@
         }
     ],
     "wof:id":85667627,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -348,7 +348,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285385,
+    "wof:lastmodified":1565634339,
     "wof:name":"Parwan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/31/85667631.geojson
+++ b/data/856/676/31/85667631.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "SM"
+    ],
     "lbl:latitude":35.916771,
     "lbl:longitude":67.786936,
     "mps:latitude":35.98416,
@@ -347,9 +350,6 @@
         }
     ],
     "wof:id":85667631,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -361,7 +361,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285388,
+    "wof:lastmodified":1565634339,
     "wof:name":"Samangan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/35/85667635.geojson
+++ b/data/856/676/35/85667635.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "VR"
+    ],
     "lbl:latitude":34.277256,
     "lbl:longitude":68.44915,
     "mps:latitude":34.255738,
@@ -342,9 +345,6 @@
         }
     ],
     "wof:id":85667635,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -356,7 +356,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285384,
+    "wof:lastmodified":1565634338,
     "wof:name":"Wardak",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/41/85667641.geojson
+++ b/data/856/676/41/85667641.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "province"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "PT"
+    ],
     "lbl:latitude":33.555903,
     "lbl:longitude":69.275376,
     "mps:latitude":33.5311,
@@ -346,9 +349,6 @@
         }
     ],
     "wof:id":85667641,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "fas",
         "pus"
@@ -360,7 +360,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1563285391,
+    "wof:lastmodified":1565634339,
     "wof:name":"Paktya",
     "wof:parent_id":85632229,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1689.

- Adds a `label:eng_x_preferred_shortcode` property to any country, macroregion, region, or dependency record
- Removes any `wof:lang` property if `wof:lang_x_official` and `wof:lang_x_spoken` properties are present

Will not require PIP work, property edits only.

Script output:

```
whosonfirst-data-admin-af
85667561,GZ
85667595,TK
85667503,BM
85667567,PK
85667505,BAL
85667527,FH
85667573,BD
85667519,GR
85667581,KR
85667509,FB
85667531,HM
85667591,NG
85667537,NM
85667555,ZB
85667563,KT
85667541,OZ
85667577,NR
85667523,SP
85667585,KZ
85667549,KD
85667513,JW
85667493,BG
85667497,HR
85632229,AF
85667603,KB
85667635,VR
85667627,PV
85667617,LA
85667609,KP
85667631,SM
85667601,BL
85667641,PT
85667623,LW
1108803081,PJ
1108803083,DK
```