### PR TITLE
geom_alt props

### DIFF
--- a/data/421/166/641/421166641.geojson
+++ b/data/421/166/641/421166641.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459008697,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"536d0a566ef04cd94ecc1c9462601ad2",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421166641,
-    "wof:lastmodified":1566583516,
+    "wof:lastmodified":1582326674,
     "wof:name":"Gardiz",
     "wof:parent_id":85667641,
     "wof:placetype":"county",

--- a/data/421/168/799/421168799.geojson
+++ b/data/421/168/799/421168799.geojson
@@ -648,6 +648,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459008781,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c9a05060f058ad5d71322e984ffb01c",
     "wof:hierarchy":[
         {
@@ -659,7 +662,7 @@
         }
     ],
     "wof:id":421168799,
-    "wof:lastmodified":1566583515,
+    "wof:lastmodified":1582326674,
     "wof:name":"Kabul",
     "wof:parent_id":421171977,
     "wof:placetype":"locality",

--- a/data/421/171/021/421171021.geojson
+++ b/data/421/171/021/421171021.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459008879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dceca665d373952875c8c7bc9343d053",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421171021,
-    "wof:lastmodified":1566583528,
+    "wof:lastmodified":1582326676,
     "wof:name":"Sarobi",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/421/171/023/421171023.geojson
+++ b/data/421/171/023/421171023.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459008879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"95ed3e42471c62fdc0266c64ad5c9f89",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421171023,
-    "wof:lastmodified":1566583527,
+    "wof:lastmodified":1582326676,
     "wof:name":"Guldara",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/421/171/025/421171025.geojson
+++ b/data/421/171/025/421171025.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459008879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6814e0db50f2b0ee93d8548ac00a801e",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421171025,
-    "wof:lastmodified":1566583527,
+    "wof:lastmodified":1582326676,
     "wof:name":"Baghran",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/421/171/977/421171977.geojson
+++ b/data/421/171/977/421171977.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459008914,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c9a05060f058ad5d71322e984ffb01c",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421171977,
-    "wof:lastmodified":1566583528,
+    "wof:lastmodified":1582326676,
     "wof:name":"Kabul",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/421/177/081/421177081.geojson
+++ b/data/421/177/081/421177081.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009132,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"806cea4acbb82067c2f246715977b69f",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421177081,
-    "wof:lastmodified":1566583525,
+    "wof:lastmodified":1582326676,
     "wof:name":"Shahrak",
     "wof:parent_id":85667519,
     "wof:placetype":"county",

--- a/data/421/182/251/421182251.geojson
+++ b/data/421/182/251/421182251.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009323,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"279ed05ba80c330983877c699de7e48e",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":421182251,
-    "wof:lastmodified":1566583526,
+    "wof:lastmodified":1582326676,
     "wof:name":"Bamyan",
     "wof:parent_id":85667503,
     "wof:placetype":"county",

--- a/data/421/182/253/421182253.geojson
+++ b/data/421/182/253/421182253.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009323,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"863e3ce69377282b7ae47e7068f51385",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421182253,
-    "wof:lastmodified":1566583527,
+    "wof:lastmodified":1582326676,
     "wof:name":"Bagrami",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/421/182/991/421182991.geojson
+++ b/data/421/182/991/421182991.geojson
@@ -216,6 +216,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009354,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b18a163917d473d3900fbbc8d169c9a",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":421182991,
-    "wof:lastmodified":1566583526,
+    "wof:lastmodified":1582326676,
     "wof:name":"Kot",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/421/183/887/421183887.geojson
+++ b/data/421/183/887/421183887.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009390,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"624ce3c9a84af4d41cca9db4d4cafa88",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421183887,
-    "wof:lastmodified":1566583526,
+    "wof:lastmodified":1582326676,
     "wof:name":"Ishkashiem",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/421/187/941/421187941.geojson
+++ b/data/421/187/941/421187941.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009528,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4f0e2e11688c911988f3959eeb71bf60",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421187941,
-    "wof:lastmodified":1566583519,
+    "wof:lastmodified":1582326675,
     "wof:name":"Wakhan",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/421/187/943/421187943.geojson
+++ b/data/421/187/943/421187943.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009528,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8053a945aded569b8d48e5529bd50b61",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421187943,
-    "wof:lastmodified":1566583521,
+    "wof:lastmodified":1582326675,
     "wof:name":"Bagram",
     "wof:parent_id":85667627,
     "wof:placetype":"county",

--- a/data/421/187/945/421187945.geojson
+++ b/data/421/187/945/421187945.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea59794e60f3436e7d69ec197a5a04ef",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421187945,
-    "wof:lastmodified":1566583521,
+    "wof:lastmodified":1582326675,
     "wof:name":"Nahri Shahi",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/421/188/181/421188181.geojson
+++ b/data/421/188/181/421188181.geojson
@@ -291,6 +291,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009537,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f8efd1cfb301dae9b8e8d68359939a8",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         }
     ],
     "wof:id":421188181,
-    "wof:lastmodified":1566583522,
+    "wof:lastmodified":1582326675,
     "wof:name":"Kunduz",
     "wof:parent_id":85667585,
     "wof:placetype":"county",

--- a/data/421/188/911/421188911.geojson
+++ b/data/421/188/911/421188911.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009588,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"76ce3a222290e2a9b15ef02f2c247551",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421188911,
-    "wof:lastmodified":1566583522,
+    "wof:lastmodified":1582326675,
     "wof:name":"Taluqan",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/421/189/841/421189841.geojson
+++ b/data/421/189/841/421189841.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009638,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"a61b1660a42efe59d4034efb0c37b97f",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":421189841,
-    "wof:lastmodified":1534379076,
+    "wof:lastmodified":1582326675,
     "wof:name":"Tarin Kowt",
     "wof:parent_id":1108562547,
     "wof:placetype":"locality",

--- a/data/421/191/409/421191409.geojson
+++ b/data/421/191/409/421191409.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009691,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"23d788fc5966148146f559eac0cdfe8c",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421191409,
-    "wof:lastmodified":1566583524,
+    "wof:lastmodified":1582326676,
     "wof:name":"Fayzabad",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/421/194/001/421194001.geojson
+++ b/data/421/194/001/421194001.geojson
@@ -84,6 +84,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009790,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8fd5acf6e503221ca1e22448f277ebdd",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":421194001,
-    "wof:lastmodified":1566583517,
+    "wof:lastmodified":1582326675,
     "wof:name":"Jabalussaraj",
     "wof:parent_id":85667627,
     "wof:placetype":"county",

--- a/data/421/194/569/421194569.geojson
+++ b/data/421/194/569/421194569.geojson
@@ -248,6 +248,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009812,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0dfba4aa45bea5ad55251bafb8b8ecd6",
     "wof:hierarchy":[
         {
@@ -258,7 +261,7 @@
         }
     ],
     "wof:id":421194569,
-    "wof:lastmodified":1566583517,
+    "wof:lastmodified":1582326674,
     "wof:name":"Lashkar Gah",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/421/194/803/421194803.geojson
+++ b/data/421/194/803/421194803.geojson
@@ -304,6 +304,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009820,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f6224f1c2dd8615b40e58bcb2353f89b",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         }
     ],
     "wof:id":421194803,
-    "wof:lastmodified":1566583517,
+    "wof:lastmodified":1582326675,
     "wof:name":"Kandahar",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/421/196/563/421196563.geojson
+++ b/data/421/196/563/421196563.geojson
@@ -84,6 +84,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009885,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2a5ce3811fbfb951be22abf3f6e7bffc",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":421196563,
-    "wof:lastmodified":1566583523,
+    "wof:lastmodified":1582326676,
     "wof:name":"Panjwayi",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/421/197/035/421197035.geojson
+++ b/data/421/197/035/421197035.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009900,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"578f2f00c2a8f0d0599419bbbf7bdaea",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421197035,
-    "wof:lastmodified":1566583524,
+    "wof:lastmodified":1582326676,
     "wof:name":"Sangin",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/421/198/905/421198905.geojson
+++ b/data/421/198/905/421198905.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009965,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98ea149f8c30e6d00d573f98fbf7c085",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421198905,
-    "wof:lastmodified":1566583523,
+    "wof:lastmodified":1582326676,
     "wof:name":"Shindand",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/421/198/931/421198931.geojson
+++ b/data/421/198/931/421198931.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459009966,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d76858e59fb14d133f84335e2883f9b9",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421198931,
-    "wof:lastmodified":1566583523,
+    "wof:lastmodified":1582326676,
     "wof:name":"Zanda Jan",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/421/202/037/421202037.geojson
+++ b/data/421/202/037/421202037.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"AF",
     "wof:created":1459010102,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"268f448a3fa5c61823d88630f1966c69",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":421202037,
-    "wof:lastmodified":1566583518,
+    "wof:lastmodified":1582326675,
     "wof:name":"Nahri Sarraj",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/421/202/359/421202359.geojson
+++ b/data/421/202/359/421202359.geojson
@@ -320,7 +320,8 @@
     "qs:woe_id":1935288,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "quattroshapes_pg"
+        "quattroshapes_pg",
+        "naturalearth"
     ],
     "src:population":"wk",
     "wd:latitude":34.430278,
@@ -343,6 +344,10 @@
     },
     "wof:country":"AF",
     "wof:created":1459010115,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "naturalearth"
+    ],
     "wof:geomhash":"c0243ae9f6585f5198d33a2fb09d5baa",
     "wof:hierarchy":[
         {
@@ -354,7 +359,7 @@
         }
     ],
     "wof:id":421202359,
-    "wof:lastmodified":1561775928,
+    "wof:lastmodified":1582326675,
     "wof:name":"Jalalabad",
     "wof:parent_id":1108562095,
     "wof:placetype":"locality",

--- a/data/856/322/29/85632229.geojson
+++ b/data/856/322/29/85632229.geojson
@@ -1077,6 +1077,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1132,6 +1133,11 @@
     },
     "wof:country":"AF",
     "wof:country_alpha3":"AFG",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"244b9bb074a87808dcfb8832564bfae5",
     "wof:hierarchy":[
         {
@@ -1151,7 +1157,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582231,
+    "wof:lastmodified":1582326644,
     "wof:name":"Afghanistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/322/29/85632229.geojson
+++ b/data/856/322/29/85632229.geojson
@@ -1077,7 +1077,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1157,7 +1156,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1582326644,
+    "wof:lastmodified":1583210379,
     "wof:name":"Afghanistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/674/93/85667493.geojson
+++ b/data/856/674/93/85667493.geojson
@@ -360,6 +360,9 @@
         "wk:page":"Badghis Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e3a14a721e587091e6a5a467538518c1",
     "wof:hierarchy":[
         {
@@ -380,7 +383,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582230,
+    "wof:lastmodified":1582326643,
     "wof:name":"Badghis",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/674/97/85667497.geojson
+++ b/data/856/674/97/85667497.geojson
@@ -358,6 +358,9 @@
         "wk:page":"Herat Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cbf242ea590ac86bcf33c3987c88dc97",
     "wof:hierarchy":[
         {
@@ -378,7 +381,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582230,
+    "wof:lastmodified":1582326643,
     "wof:name":"Hirat",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/03/85667503.geojson
+++ b/data/856/675/03/85667503.geojson
@@ -366,6 +366,9 @@
         "wk:page":"Bamyan Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bd3057b53f7bd600c80d7bb730f81101",
     "wof:hierarchy":[
         {
@@ -386,7 +389,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582221,
+    "wof:lastmodified":1582326639,
     "wof:name":"Bamyan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/05/85667505.geojson
+++ b/data/856/675/05/85667505.geojson
@@ -360,6 +360,9 @@
         "wk:page":"Balkh Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"06bd652e3fc1becda83f3e45dcb390f2",
     "wof:hierarchy":[
         {
@@ -380,7 +383,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582222,
+    "wof:lastmodified":1582326639,
     "wof:name":"Balkh",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/09/85667509.geojson
+++ b/data/856/675/09/85667509.geojson
@@ -369,6 +369,9 @@
         "wk:page":"Faryab Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3556318120bd618b64e120647542aae8",
     "wof:hierarchy":[
         {
@@ -389,7 +392,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582224,
+    "wof:lastmodified":1582326641,
     "wof:name":"Faryab",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/13/85667513.geojson
+++ b/data/856/675/13/85667513.geojson
@@ -351,6 +351,9 @@
         "wk:page":"Jowzjan Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f487bddbe81b190e310fc2c5400790c",
     "wof:hierarchy":[
         {
@@ -371,7 +374,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582229,
+    "wof:lastmodified":1582326643,
     "wof:name":"Jawzjan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/19/85667519.geojson
+++ b/data/856/675/19/85667519.geojson
@@ -338,6 +338,9 @@
         "wk:page":"Ghor Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ea8662eb140fa2e2a87d405bafd334e",
     "wof:hierarchy":[
         {
@@ -358,7 +361,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582224,
+    "wof:lastmodified":1582326640,
     "wof:name":"Ghor",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/23/85667523.geojson
+++ b/data/856/675/23/85667523.geojson
@@ -330,6 +330,9 @@
         "wd:id":"Q182487"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d10781c6e476c19af3da72ee7a61900",
     "wof:hierarchy":[
         {
@@ -350,7 +353,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582228,
+    "wof:lastmodified":1582326642,
     "wof:name":"Sari Pul",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/27/85667527.geojson
+++ b/data/856/675/27/85667527.geojson
@@ -345,6 +345,9 @@
         "wk:page":"Farah Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"588897f9533ca64efc94d21ed0b2b1b5",
     "wof:hierarchy":[
         {
@@ -365,7 +368,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582222,
+    "wof:lastmodified":1582326639,
     "wof:name":"Farah",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/31/85667531.geojson
+++ b/data/856/675/31/85667531.geojson
@@ -373,6 +373,9 @@
         "wk:page":"Helmand Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"40029f51615d4eb332be7d499f7f3acb",
     "wof:hierarchy":[
         {
@@ -393,7 +396,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582225,
+    "wof:lastmodified":1582326641,
     "wof:name":"Hilmand",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/37/85667537.geojson
+++ b/data/856/675/37/85667537.geojson
@@ -351,6 +351,9 @@
         "wk:page":"Nimruz Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8aa9f622afe713caa22a33abc718b682",
     "wof:hierarchy":[
         {
@@ -371,7 +374,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582226,
+    "wof:lastmodified":1582326641,
     "wof:name":"Nimroz",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/41/85667541.geojson
+++ b/data/856/675/41/85667541.geojson
@@ -370,6 +370,9 @@
         "wk:page":"Urozgan Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19f1dca20ba79918789d1e271cdd8e17",
     "wof:hierarchy":[
         {
@@ -390,7 +393,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582227,
+    "wof:lastmodified":1582326642,
     "wof:name":"Uruzgan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/49/85667549.geojson
+++ b/data/856/675/49/85667549.geojson
@@ -345,6 +345,9 @@
         "wk:page":"Kandahar Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66f5abc30cfe9c21c737b63b785c97b1",
     "wof:hierarchy":[
         {
@@ -365,7 +368,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582228,
+    "wof:lastmodified":1582326642,
     "wof:name":"Kandahar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/55/85667555.geojson
+++ b/data/856/675/55/85667555.geojson
@@ -352,6 +352,9 @@
         "wk:page":"Zabul Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"32fcca1ca298a4ab3a955d3eb093dd5d",
     "wof:hierarchy":[
         {
@@ -372,7 +375,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582226,
+    "wof:lastmodified":1582326641,
     "wof:name":"Zabul",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/61/85667561.geojson
+++ b/data/856/675/61/85667561.geojson
@@ -351,6 +351,9 @@
         "wk:page":"Ghazni Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fedb02663962cb2e8f02bfa9093e73a9",
     "wof:hierarchy":[
         {
@@ -371,7 +374,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582220,
+    "wof:lastmodified":1582326638,
     "wof:name":"Ghazni",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/63/85667563.geojson
+++ b/data/856/675/63/85667563.geojson
@@ -347,6 +347,9 @@
         "wk:page":"Khost Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f0537728e544887a1d4a7bb503a1307",
     "wof:hierarchy":[
         {
@@ -367,7 +370,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582227,
+    "wof:lastmodified":1582326642,
     "wof:name":"Khost",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/67/85667567.geojson
+++ b/data/856/675/67/85667567.geojson
@@ -321,6 +321,9 @@
         "wk:page":"Paktika Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b07d9b72bf927f14f5a42ed1e42e47d9",
     "wof:hierarchy":[
         {
@@ -341,7 +344,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582221,
+    "wof:lastmodified":1582326639,
     "wof:name":"Paktika",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/73/85667573.geojson
+++ b/data/856/675/73/85667573.geojson
@@ -372,6 +372,9 @@
         "wk:page":"Badakhshan Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"42db882abff59fa262053719005c48c2",
     "wof:hierarchy":[
         {
@@ -392,7 +395,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582222,
+    "wof:lastmodified":1582326639,
     "wof:name":"Badakhshan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/77/85667577.geojson
+++ b/data/856/675/77/85667577.geojson
@@ -362,6 +362,9 @@
         "wk:page":"Nuristan Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"080f42bf0cef44775e2d1170fd3ba9c0",
     "wof:hierarchy":[
         {
@@ -382,7 +385,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582228,
+    "wof:lastmodified":1582326642,
     "wof:name":"Nuristan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/81/85667581.geojson
+++ b/data/856/675/81/85667581.geojson
@@ -342,6 +342,9 @@
         "wk:page":"Kunar Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2fd3e8f9a746578831354bbc0a7073fa",
     "wof:hierarchy":[
         {
@@ -362,7 +365,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582224,
+    "wof:lastmodified":1582326640,
     "wof:name":"Kunar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/85/85667585.geojson
+++ b/data/856/675/85/85667585.geojson
@@ -374,6 +374,9 @@
         "wk:page":"Kunduz Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c125e5bccb80c2ee9509e31126bc8a2c",
     "wof:hierarchy":[
         {
@@ -394,7 +397,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582228,
+    "wof:lastmodified":1582326642,
     "wof:name":"Kunduz",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/91/85667591.geojson
+++ b/data/856/675/91/85667591.geojson
@@ -345,6 +345,9 @@
         "wk:page":"Nangarhar Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"717129ea4e36b960a74b681afae93263",
     "wof:hierarchy":[
         {
@@ -365,7 +368,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582225,
+    "wof:lastmodified":1582326641,
     "wof:name":"Nangarhar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/95/85667595.geojson
+++ b/data/856/675/95/85667595.geojson
@@ -342,6 +342,9 @@
         "wk:page":"Takhar Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d9c8a1421c63d9b169bff3353355d27b",
     "wof:hierarchy":[
         {
@@ -362,7 +365,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582220,
+    "wof:lastmodified":1582326638,
     "wof:name":"Takhar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/01/85667601.geojson
+++ b/data/856/676/01/85667601.geojson
@@ -348,6 +348,9 @@
         "wk:page":"Baghlan Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37ca50a8d1ef819b3716db539d17654c",
     "wof:hierarchy":[
         {
@@ -368,7 +371,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582237,
+    "wof:lastmodified":1582326647,
     "wof:name":"Baghlan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/03/85667603.geojson
+++ b/data/856/676/03/85667603.geojson
@@ -348,6 +348,9 @@
         "wk:page":"Kabul Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"951838abb96812fdca40bbff07bdc1fd",
     "wof:hierarchy":[
         {
@@ -368,7 +371,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582236,
+    "wof:lastmodified":1582326646,
     "wof:name":"Kabul",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/09/85667609.geojson
+++ b/data/856/676/09/85667609.geojson
@@ -345,6 +345,9 @@
         "wk:page":"Kapisa Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"775caba5058e7a9d564fd847cbca4819",
     "wof:hierarchy":[
         {
@@ -365,7 +368,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582236,
+    "wof:lastmodified":1582326647,
     "wof:name":"Kapisa",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/17/85667617.geojson
+++ b/data/856/676/17/85667617.geojson
@@ -342,6 +342,9 @@
         "wk:page":"Laghman Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a694b0554d9e9efba39550e3e0036cb",
     "wof:hierarchy":[
         {
@@ -362,7 +365,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582236,
+    "wof:lastmodified":1582326647,
     "wof:name":"Laghman",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/23/85667623.geojson
+++ b/data/856/676/23/85667623.geojson
@@ -348,6 +348,9 @@
         "wk:page":"Logar Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0cbdbe62c709ac269ae8b2ca1d1ebeef",
     "wof:hierarchy":[
         {
@@ -368,7 +371,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582237,
+    "wof:lastmodified":1582326647,
     "wof:name":"Logar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/27/85667627.geojson
+++ b/data/856/676/27/85667627.geojson
@@ -329,6 +329,9 @@
         "wk:page":"Panjshir Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2782ff19715bbc6e81999dc965617e9",
     "wof:hierarchy":[
         {
@@ -349,7 +352,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582236,
+    "wof:lastmodified":1582326647,
     "wof:name":"Parwan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/31/85667631.geojson
+++ b/data/856/676/31/85667631.geojson
@@ -342,6 +342,9 @@
         "wk:page":"Samangan Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e7ab0b48e525a7d8c9c0c8fa61f59e56",
     "wof:hierarchy":[
         {
@@ -362,7 +365,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582237,
+    "wof:lastmodified":1582326647,
     "wof:name":"Samangan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/35/85667635.geojson
+++ b/data/856/676/35/85667635.geojson
@@ -337,6 +337,9 @@
         "wk:page":"Maidan Wardak Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"39cfcdf7c9fa7ddf6be94e066418e51b",
     "wof:hierarchy":[
         {
@@ -357,7 +360,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582236,
+    "wof:lastmodified":1582326647,
     "wof:name":"Wardak",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/41/85667641.geojson
+++ b/data/856/676/41/85667641.geojson
@@ -341,6 +341,9 @@
         "wk:page":"Paktia Province"
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72c4e4816d488bdc8a1969872accce60",
     "wof:hierarchy":[
         {
@@ -361,7 +364,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1566582237,
+    "wof:lastmodified":1582326647,
     "wof:name":"Paktya",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/859/029/79/85902979.geojson
+++ b/data/859/029/79/85902979.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":894751
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"196a601adb12ec84f2f0a354fa5b54bd",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566582219,
+    "wof:lastmodified":1582326637,
     "wof:name":"B\u012bb\u012b Mahr\u016b",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/81/85902981.geojson
+++ b/data/859/029/81/85902981.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":1119342
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a1eaa2cdc2f5bece328ce5010c5c52c9",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566582219,
+    "wof:lastmodified":1582326637,
     "wof:name":"Chaman H\u0327o\u1e95\u016br\u012b",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/83/85902983.geojson
+++ b/data/859/029/83/85902983.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":1119344
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"86a00bbc7face4c0f6c82990e4f42e81",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566582220,
+    "wof:lastmodified":1582326637,
     "wof:name":"D\u00e5r ol Am\u00e5n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/85/85902985.geojson
+++ b/data/859/029/85/85902985.geojson
@@ -84,6 +84,9 @@
         "qs_pg:id":1168188
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3552da3e342fdd294a341144312d5ccb",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566582220,
+    "wof:lastmodified":1582326637,
     "wof:name":"Deh Mazang",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/87/85902987.geojson
+++ b/data/859/029/87/85902987.geojson
@@ -99,6 +99,9 @@
         "qs_pg:id":1168185
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4ccaf8f2f3c5479b71d25c187090336",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566582219,
+    "wof:lastmodified":1582326637,
     "wof:name":"\u1e0eeh\u1e0f\u0101n\u0101",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/89/85902989.geojson
+++ b/data/859/029/89/85902989.geojson
@@ -89,6 +89,9 @@
         "qs:id":1168189
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"479735331f99f52d2dc27544f6d02fbd",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1534379076,
+    "wof:lastmodified":1582326637,
     "wof:name":"K\u0101rteh-ye Val\u012b",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/91/85902991.geojson
+++ b/data/859/029/91/85902991.geojson
@@ -77,6 +77,9 @@
         "gp:id":1928716
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f68d806b5f81b6ae0ccd0b71c9696606",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566582219,
+    "wof:lastmodified":1582326637,
     "wof:name":"Qal\u00e5-ye Chaman",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/029/95/85902995.geojson
+++ b/data/859/029/95/85902995.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":493084
     },
     "wof:country":"AF",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"63c2a40bc2fcc10577a39d807fb72c36",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566582219,
+    "wof:lastmodified":1582326637,
     "wof:name":"Shahr-e Now",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/443/561/890443561.geojson
+++ b/data/890/443/561/890443561.geojson
@@ -282,6 +282,9 @@
     },
     "wof:country":"AF",
     "wof:created":1469052429,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"4a91cf1a8a1c3429e001856fc4958ccd",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
         }
     ],
     "wof:id":890443561,
-    "wof:lastmodified":1566583534,
+    "wof:lastmodified":1582326676,
     "wof:name":"Qala i Naw",
     "wof:parent_id":1108562377,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.