### PR TITLE
Update properties of megacities

### DIFF
--- a/data/421/168/799/421168799.geojson
+++ b/data/421/168/799/421168799.geojson
@@ -680,6 +680,7 @@
         "gn:id":1138958,
         "gp:id":1922738,
         "loc:id":"n80056678",
+        "ne:id":1159151561,
         "qs_pg:id":275988,
         "wd:id":"Q5838",
         "wk:page":"Kabul"
@@ -703,7 +704,8 @@
         }
     ],
     "wof:id":421168799,
-    "wof:lastmodified":1608039797,
+    "wof:lastmodified":1608688191,
+    "wof:megacity":1,
     "wof:name":"Kabul",
     "wof:parent_id":421171977,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary