### PR TITLE
af concordances, placetype local, and more

### DIFF
--- a/data/110/856/177/3/1108561773.geojson
+++ b/data/110/856/177/3/1108561773.geojson
@@ -111,6 +111,7 @@
         "hasc:id":"AF.GZ.AB",
         "wd:id":"Q3694483"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049879,
     "wof:geomhash":"be56036f96be39fea9ba315087435e63",
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108561773,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886695,
     "wof:name":"Ab Band",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/177/5/1108561775.geojson
+++ b/data/110/856/177/5/1108561775.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"AF.BG.QN",
         "wd:id":"Q2572213"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049881,
     "wof:geomhash":"87dcbadaa284ffaeb7a6c5fefb6918c1",
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108561775,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886695,
     "wof:name":"Ab Kamari",
     "wof:parent_id":85667493,
     "wof:placetype":"county",

--- a/data/110/856/177/7/1108561777.geojson
+++ b/data/110/856/177/7/1108561777.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"AF.NG.AC",
         "wd:id":"Q1650529"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049882,
     "wof:geomhash":"a00b0bd91608c3cfcb30bda39a21ff64",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108561777,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886695,
     "wof:name":"Acheen",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/178/1/1108561781.geojson
+++ b/data/110/856/178/1/1108561781.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HR.AD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049883,
     "wof:geomhash":"a0e7182fc0380039a8d15cc28c7af2f0",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108561781,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886695,
     "wof:name":"Adraskan",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/178/3/1108561783.geojson
+++ b/data/110/856/178/3/1108561783.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PT.AH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049884,
     "wof:geomhash":"e194a3d2d7c65712fb021102a41ec6ac",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108561783,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886695,
     "wof:name":"Ahmad Abad",
     "wof:parent_id":85667641,
     "wof:placetype":"county",

--- a/data/110/856/178/5/1108561785.geojson
+++ b/data/110/856/178/5/1108561785.geojson
@@ -117,6 +117,7 @@
         "hasc:id":"AF.GZ.AJ",
         "wd:id":"Q2674014"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049885,
     "wof:geomhash":"cf0bc40db1b079ded24f164fccfc52ea",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108561785,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886695,
     "wof:name":"Ajristan",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/178/7/1108561787.geojson
+++ b/data/110/856/178/7/1108561787.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KP.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049886,
     "wof:geomhash":"fe219affad67d57b59cc6ea18e853635",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561787,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886695,
     "wof:name":"Alasay",
     "wof:parent_id":85667609,
     "wof:placetype":"county",

--- a/data/110/856/178/9/1108561789.geojson
+++ b/data/110/856/178/9/1108561789.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PT.JJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049887,
     "wof:geomhash":"d8dfd2a59009c7af382a8096fc2f8724",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561789,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886695,
     "wof:name":"Ali Khail (Jaji)",
     "wof:parent_id":85667641,
     "wof:placetype":"county",

--- a/data/110/856/179/1/1108561791.geojson
+++ b/data/110/856/179/1/1108561791.geojson
@@ -98,6 +98,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KZ.AA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049888,
     "wof:geomhash":"1e0e1b264c1a19104cbb03888a79a208",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108561791,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886695,
     "wof:name":"Aliabad",
     "wof:parent_id":85667585,
     "wof:placetype":"county",

--- a/data/110/856/179/3/1108561793.geojson
+++ b/data/110/856/179/3/1108561793.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"AF.LA.AN",
         "wd:id":"Q1229725"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049889,
     "wof:geomhash":"eab0dec8eb4789a4ab23395c09ebabc1",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108561793,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886695,
     "wof:name":"Alingar",
     "wof:parent_id":85667617,
     "wof:placetype":"county",

--- a/data/110/856/179/5/1108561795.geojson
+++ b/data/110/856/179/5/1108561795.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"AF.LA.AS",
         "wd:id":"Q4726991"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049890,
     "wof:geomhash":"8b4ce01ce0910f14ff3997c5c56fa4c8",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108561795,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886695,
     "wof:name":"Alishing",
     "wof:parent_id":85667617,
     "wof:placetype":"county",

--- a/data/110/856/179/9/1108561799.geojson
+++ b/data/110/856/179/9/1108561799.geojson
@@ -116,6 +116,7 @@
         "hasc:id":"AF.FB.AL",
         "wd:id":"Q3694490"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049891,
     "wof:geomhash":"5db93b867605adfaee643e114233fa23",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108561799,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886696,
     "wof:name":"Almar",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/180/1/1108561801.geojson
+++ b/data/110/856/180/1/1108561801.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.FH.AD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049892,
     "wof:geomhash":"01c7950e0c9aa8ab904c5d69f21381ca",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561801,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886696,
     "wof:name":"Anar Dara",
     "wof:parent_id":85667527,
     "wof:placetype":"county",

--- a/data/110/856/180/3/1108561803.geojson
+++ b/data/110/856/180/3/1108561803.geojson
@@ -131,6 +131,7 @@
         "hasc:id":"AF.BL.AN",
         "wd:id":"Q2376379"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049893,
     "wof:geomhash":"88a6431e6a57d7899cfec3417568749d",
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108561803,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886616,
     "wof:name":"Andarab",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/180/5/1108561805.geojson
+++ b/data/110/856/180/5/1108561805.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GZ.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049895,
     "wof:geomhash":"bfd288aed5c16bca2c9b9f77f0ff4204",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561805,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886696,
     "wof:name":"Andar",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/180/7/1108561807.geojson
+++ b/data/110/856/180/7/1108561807.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"AF.FB.AN",
         "wd:id":"Q13217328"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049896,
     "wof:geomhash":"ad9459c1e30fbffb48278da471778c20",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108561807,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886616,
     "wof:name":"Andkhoy",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/180/9/1108561809.geojson
+++ b/data/110/856/180/9/1108561809.geojson
@@ -103,6 +103,7 @@
     "wof:concordances":{
         "hasc:id":"AF.JW.AQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049897,
     "wof:geomhash":"2a5498f2b5de431d3283912f299d7a1b",
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108561809,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886616,
     "wof:name":"Aqcha",
     "wof:parent_id":85667513,
     "wof:placetype":"county",

--- a/data/110/856/181/1/1108561811.geojson
+++ b/data/110/856/181/1/1108561811.geojson
@@ -137,6 +137,7 @@
         "hasc:id":"AF.KD.AD",
         "wd:id":"Q1920624"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049898,
     "wof:geomhash":"89e642c004da5dd6f8e544fa758ffa59",
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108561811,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886616,
     "wof:name":"Arghandab",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/181/3/1108561813.geojson
+++ b/data/110/856/181/3/1108561813.geojson
@@ -91,6 +91,7 @@
     "wof:concordances":{
         "hasc:id":"AF.ZB.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049899,
     "wof:geomhash":"39b1d1276efda44362281e24a3ce4adf",
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108561813,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886616,
     "wof:name":"Arghandab",
     "wof:parent_id":85667555,
     "wof:placetype":"county",

--- a/data/110/856/181/7/1108561817.geojson
+++ b/data/110/856/181/7/1108561817.geojson
@@ -132,6 +132,7 @@
         "hasc:id":"AF.BD.AK",
         "wd:id":"Q2669827"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049900,
     "wof:geomhash":"1e69ceaeb78a6593ee444302e00b96d5",
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108561817,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886616,
     "wof:name":"Arghanj Khaw",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/181/9/1108561819.geojson
+++ b/data/110/856/181/9/1108561819.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KD.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049901,
     "wof:geomhash":"6a3a8d7d8caa1227b881ccaf43501b2a",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108561819,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886616,
     "wof:name":"Arghistan",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/182/1/1108561821.geojson
+++ b/data/110/856/182/1/1108561821.geojson
@@ -131,6 +131,7 @@
         "hasc:id":"AF.BD.AR",
         "wd:id":"Q2670898"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049902,
     "wof:geomhash":"b7250f0f6d281ce746e4e5714d7095ae",
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108561821,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886620,
     "wof:name":"Argo",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/182/3/1108561823.geojson
+++ b/data/110/856/182/3/1108561823.geojson
@@ -114,6 +114,7 @@
         "hasc:id":"AF.KR.AA",
         "wd:id":"Q2663257"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049903,
     "wof:geomhash":"20d97920ceb234bd5ec598c26629aec9",
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108561823,
-    "wof:lastmodified":1694498102,
+    "wof:lastmodified":1695886729,
     "wof:name":"Asadabad",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/182/5/1108561825.geojson
+++ b/data/110/856/182/5/1108561825.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.ZB.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049904,
     "wof:geomhash":"c192e30cb809ff32c983a0c46808e8ea",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108561825,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886696,
     "wof:name":"Atghar",
     "wof:parent_id":85667555,
     "wof:placetype":"county",

--- a/data/110/856/182/7/1108561827.geojson
+++ b/data/110/856/182/7/1108561827.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"AF.SM.AY",
         "wd:id":"Q3694404"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049905,
     "wof:geomhash":"c646e04b265632d36f8260daa09ac5f0",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108561827,
-    "wof:lastmodified":1694498102,
+    "wof:lastmodified":1695886729,
     "wof:name":"Aybak",
     "wof:parent_id":85667631,
     "wof:placetype":"county",

--- a/data/110/856/182/9/1108561829.geojson
+++ b/data/110/856/182/9/1108561829.geojson
@@ -107,6 +107,7 @@
     "wof:concordances":{
         "hasc:id":"AF.LW.AZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049906,
     "wof:geomhash":"da4351ae73963c699254fda914b28f55",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108561829,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886620,
     "wof:name":"Azra",
     "wof:parent_id":85667623,
     "wof:placetype":"county",

--- a/data/110/856/183/1/1108561831.geojson
+++ b/data/110/856/183/1/1108561831.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BL.BJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049907,
     "wof:geomhash":"aad1738a716ac23e016042047d91d0aa",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108561831,
-    "wof:lastmodified":1694497950,
+    "wof:lastmodified":1695886696,
     "wof:name":"Baghlani Jadid",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/183/5/1108561835.geojson
+++ b/data/110/856/183/5/1108561835.geojson
@@ -116,6 +116,7 @@
         "hasc:id":"AF.BD.BA",
         "wd:id":"Q3918397"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049910,
     "wof:geomhash":"e3c0c939a648c2656450f87d39f6bdf9",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108561835,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886620,
     "wof:name":"Baharak",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/183/7/1108561837.geojson
+++ b/data/110/856/183/7/1108561837.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"AF.TK.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049911,
     "wof:geomhash":"c079d79c046b2ae3e388606747f7a68d",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108561837,
-    "wof:lastmodified":1694497950,
+    "wof:lastmodified":1695886696,
     "wof:name":"Baharak",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/183/9/1108561839.geojson
+++ b/data/110/856/183/9/1108561839.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GZ.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049912,
     "wof:geomhash":"ad971993229e668f877cd0832f0611c0",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108561839,
-    "wof:lastmodified":1694497950,
+    "wof:lastmodified":1695886696,
     "wof:name":"Bahrami Shahid (Jaghatu)",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/184/1/1108561841.geojson
+++ b/data/110/856/184/1/1108561841.geojson
@@ -112,6 +112,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KT.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049913,
     "wof:geomhash":"c9927a7174a129a02572771558f78969",
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108561841,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886620,
     "wof:name":"Bak",
     "wof:parent_id":85667563,
     "wof:placetype":"county",

--- a/data/110/856/184/3/1108561843.geojson
+++ b/data/110/856/184/3/1108561843.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"AF.FH.BA",
         "wd:id":"Q1812576"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049914,
     "wof:geomhash":"3626e624c1ad8706012b147ac8fe3492",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108561843,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886620,
     "wof:name":"Bakwa",
     "wof:parent_id":85667527,
     "wof:placetype":"county",

--- a/data/110/856/184/5/1108561845.geojson
+++ b/data/110/856/184/5/1108561845.geojson
@@ -120,6 +120,7 @@
         "hasc:id":"AF.FH.BB",
         "wd:id":"Q2380868"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049915,
     "wof:geomhash":"dd3667cf142baf96c1e1785a284f7a98",
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108561845,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886620,
     "wof:name":"Bala Buluk",
     "wof:parent_id":85667527,
     "wof:placetype":"county",

--- a/data/110/856/184/7/1108561847.geojson
+++ b/data/110/856/184/7/1108561847.geojson
@@ -120,6 +120,7 @@
         "hasc:id":"AF.BG.MR",
         "wd:id":"Q2429792"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049916,
     "wof:geomhash":"37aab405a8a9e725e92bcf0c54819cb7",
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108561847,
-    "wof:lastmodified":1694497950,
+    "wof:lastmodified":1695886696,
     "wof:name":"Bala Murghab",
     "wof:parent_id":85667493,
     "wof:placetype":"county",

--- a/data/110/856/184/9/1108561849.geojson
+++ b/data/110/856/184/9/1108561849.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"AF.SP.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049917,
     "wof:geomhash":"2d72410e44150e3c483c9cc38d3d2041",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561849,
-    "wof:lastmodified":1694497950,
+    "wof:lastmodified":1695886697,
     "wof:name":"Balkhab",
     "wof:parent_id":85667523,
     "wof:placetype":"county",

--- a/data/110/856/185/3/1108561853.geojson
+++ b/data/110/856/185/3/1108561853.geojson
@@ -229,6 +229,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BK.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049918,
     "wof:geomhash":"85f62eb559aadef0da5583aee0fc0210",
@@ -241,7 +242,7 @@
         }
     ],
     "wof:id":1108561853,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886620,
     "wof:name":"Balkh",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/185/5/1108561855.geojson
+++ b/data/110/856/185/5/1108561855.geojson
@@ -79,6 +79,7 @@
     "wof:concordances":{
         "hasc:id":"AF.TK.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049920,
     "wof:geomhash":"40ccd50586c175ebf5d42ea9f3c00c8a",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108561855,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886620,
     "wof:name":"Bangi",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/185/7/1108561857.geojson
+++ b/data/110/856/185/7/1108561857.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"AF.KR.BK",
         "wd:id":"Q798468"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049921,
     "wof:geomhash":"6e002c50df34ebf25d50229a75eddf0b",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108561857,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886706,
     "wof:name":"Bar Kunar",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/185/9/1108561859.geojson
+++ b/data/110/856/185/9/1108561859.geojson
@@ -137,6 +137,7 @@
     "wof:concordances":{
         "hasc:id":"AF.LW.BB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049927,
     "wof:geomhash":"49bbb789a4abf49573f089a6fc113e14",
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108561859,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886729,
     "wof:name":"Baraki Barak",
     "wof:parent_id":85667623,
     "wof:placetype":"county",

--- a/data/110/856/186/1/1108561861.geojson
+++ b/data/110/856/186/1/1108561861.geojson
@@ -114,6 +114,7 @@
         "hasc:id":"AF.NR.BM",
         "wd:id":"Q3696136"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049928,
     "wof:geomhash":"65d3af298e648ac0ef2b5be7327098c1",
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108561861,
-    "wof:lastmodified":1694497950,
+    "wof:lastmodified":1695886697,
     "wof:name":"Bargi Matal",
     "wof:parent_id":85667577,
     "wof:placetype":"county",

--- a/data/110/856/186/3/1108561863.geojson
+++ b/data/110/856/186/3/1108561863.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049929,
     "wof:geomhash":"0610daabe35e4788ec646973d259fae7",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561863,
-    "wof:lastmodified":1694497950,
+    "wof:lastmodified":1695886697,
     "wof:name":"Barmal",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/186/5/1108561865.geojson
+++ b/data/110/856/186/5/1108561865.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049930,
     "wof:geomhash":"3dca2fb82476e5529cf8b0b84330e33f",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561865,
-    "wof:lastmodified":1694497950,
+    "wof:lastmodified":1695886697,
     "wof:name":"Bati Kot",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/186/7/1108561867.geojson
+++ b/data/110/856/186/7/1108561867.geojson
@@ -105,6 +105,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PJ.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049931,
     "wof:geomhash":"c269c0e2d645af7f74fd416a65a576e5",
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108561867,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886616,
     "wof:name":"Bazarak",
     "wof:parent_id":1108803081,
     "wof:placetype":"county",

--- a/data/110/856/187/1/1108561871.geojson
+++ b/data/110/856/187/1/1108561871.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.BI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049932,
     "wof:geomhash":"1ba0452998d542869e7130d05019b722",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561871,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886709,
     "wof:name":"Bihsud",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/187/3/1108561873.geojson
+++ b/data/110/856/187/3/1108561873.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.FB.BI",
         "wd:id":"Q4907641"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049933,
     "wof:geomhash":"458461df7370a358fbb08285ac3bfb23",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108561873,
-    "wof:lastmodified":1694497950,
+    "wof:lastmodified":1695886697,
     "wof:name":"Bilchiragh",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/187/5/1108561875.geojson
+++ b/data/110/856/187/5/1108561875.geojson
@@ -82,6 +82,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BL.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049934,
     "wof:geomhash":"fa37aec5ba69364ba6d6a4c118569191",
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108561875,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886616,
     "wof:name":"Burka",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/187/7/1108561877.geojson
+++ b/data/110/856/187/7/1108561877.geojson
@@ -157,6 +157,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GR.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049936,
     "wof:geomhash":"20e0c2fe9853cf766eb4ccc38c051034",
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":1108561877,
-    "wof:lastmodified":1694498102,
+    "wof:lastmodified":1695886728,
     "wof:name":"Chaghcharan",
     "wof:parent_id":85667519,
     "wof:placetype":"county",

--- a/data/110/856/187/9/1108561879.geojson
+++ b/data/110/856/187/9/1108561879.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.TK.CA",
         "wd:id":"Q2468989"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049937,
     "wof:geomhash":"98ad56a1de55e9b8b992741261cd52fe",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108561879,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886616,
     "wof:name":"Chah Ab",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/188/1/1108561881.geojson
+++ b/data/110/856/188/1/1108561881.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KB.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049938,
     "wof:geomhash":"c937252cac3d53d6ac7b86f6b7ed1f29",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561881,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886697,
     "wof:name":"Chahar Asyab",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/110/856/188/3/1108561883.geojson
+++ b/data/110/856/188/3/1108561883.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BK.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049939,
     "wof:geomhash":"ca1682e3322ea4479903ffc249a80ed0",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561883,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886697,
     "wof:name":"Chahar Bolak",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/188/5/1108561885.geojson
+++ b/data/110/856/188/5/1108561885.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NM.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049940,
     "wof:geomhash":"14670a1d17b17fcb3665a63682091fd2",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561885,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886697,
     "wof:name":"Chahar Burjak",
     "wof:parent_id":85667537,
     "wof:placetype":"county",

--- a/data/110/856/188/9/1108561889.geojson
+++ b/data/110/856/188/9/1108561889.geojson
@@ -108,6 +108,7 @@
         "hasc:id":"AF.KZ.CD",
         "wd:id":"Q1062874"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049941,
     "wof:geomhash":"c3d0378ca917eac3cf99163118da0188",
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108561889,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886697,
     "wof:name":"Chahar Dara",
     "wof:parent_id":85667585,
     "wof:placetype":"county",

--- a/data/110/856/189/1/1108561891.geojson
+++ b/data/110/856/189/1/1108561891.geojson
@@ -117,6 +117,7 @@
         "hasc:id":"AF.BK.CK",
         "wd:id":"Q3694271"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049942,
     "wof:geomhash":"35c53091073136cd1b43e48e93130556",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108561891,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886697,
     "wof:name":"Chahar Kint",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/189/3/1108561893.geojson
+++ b/data/110/856/189/3/1108561893.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PV.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049943,
     "wof:geomhash":"e2595b5418eb7a184772ea6ecf886eed",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561893,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886697,
     "wof:name":"Chaharikar",
     "wof:parent_id":85667627,
     "wof:placetype":"county",

--- a/data/110/856/189/5/1108561895.geojson
+++ b/data/110/856/189/5/1108561895.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.NM.CH",
         "wd:id":"Q388289"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049944,
     "wof:geomhash":"7251a4a898f5c6ad509520f9a89ccc30",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108561895,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886698,
     "wof:name":"Chakhansur",
     "wof:parent_id":85667537,
     "wof:placetype":"county",

--- a/data/110/856/189/7/1108561897.geojson
+++ b/data/110/856/189/7/1108561897.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.VR.CH",
         "wd:id":"Q1059332"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049945,
     "wof:geomhash":"636b6d4a07474df8c9a7f2be9f0ce77d",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108561897,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886616,
     "wof:name":"Chaki Wardak",
     "wof:parent_id":85667635,
     "wof:placetype":"county",

--- a/data/110/856/189/9/1108561899.geojson
+++ b/data/110/856/189/9/1108561899.geojson
@@ -88,6 +88,7 @@
     "wof:concordances":{
         "hasc:id":"AF.TK.CL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049946,
     "wof:geomhash":"1274454bbebc785c9a2c34783193d43a",
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108561899,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886616,
     "wof:name":"Chal",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/190/1/1108561901.geojson
+++ b/data/110/856/190/1/1108561901.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PT.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049947,
     "wof:geomhash":"e70eccef6c69cbc22b75d1d04678f2f7",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561901,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886698,
     "wof:name":"Chamkani",
     "wof:parent_id":85667641,
     "wof:placetype":"county",

--- a/data/110/856/190/3/1108561903.geojson
+++ b/data/110/856/190/3/1108561903.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.KR.CD",
         "wd:id":"Q798508"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049948,
     "wof:geomhash":"b6392e46c186b4a731fda354bb004839",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108561903,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886698,
     "wof:name":"Chapa Dara",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/190/7/1108561907.geojson
+++ b/data/110/856/190/7/1108561907.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049949,
     "wof:geomhash":"3fd2b2a81c52dee28a9e72256eca4221",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108561907,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886698,
     "wof:name":"Chaparhar",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/190/9/1108561909.geojson
+++ b/data/110/856/190/9/1108561909.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.LW.CH",
         "wd:id":"Q2215285"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049950,
     "wof:geomhash":"49657d34847eac670feab505734383fa",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108561909,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886698,
     "wof:name":"Charkh",
     "wof:parent_id":85667623,
     "wof:placetype":"county",

--- a/data/110/856/191/1/1108561911.geojson
+++ b/data/110/856/191/1/1108561911.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GR.CD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049951,
     "wof:geomhash":"5ee3dc7f2b196d6bf4f07c03cc571bc1",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561911,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886698,
     "wof:name":"Charsada",
     "wof:parent_id":85667519,
     "wof:placetype":"county",

--- a/data/110/856/191/3/1108561913.geojson
+++ b/data/110/856/191/3/1108561913.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"AF.KR.CH",
         "wd:id":"Q2665173"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049952,
     "wof:geomhash":"0d4188c1f21e31306eff54c48e5d0b34",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108561913,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886698,
     "wof:name":"Chawkay",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/191/5/1108561915.geojson
+++ b/data/110/856/191/5/1108561915.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BK.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049953,
     "wof:geomhash":"e4940bfd613320c650044ceb84ad3890",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561915,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886698,
     "wof:name":"Chimtal",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/191/7/1108561917.geojson
+++ b/data/110/856/191/7/1108561917.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HR.CS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049954,
     "wof:geomhash":"bc5ffdad675b861f5a5b1210529e003e",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561917,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886698,
     "wof:name":"Chishti Sharif",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/191/9/1108561919.geojson
+++ b/data/110/856/191/9/1108561919.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"AF.OZ.CH",
         "wd:id":"Q1076307"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049955,
     "wof:geomhash":"6214c141e25d35e2b8603286173a599c",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108561919,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886698,
     "wof:name":"Chora",
     "wof:parent_id":85667541,
     "wof:placetype":"county",

--- a/data/110/856/192/1/1108561921.geojson
+++ b/data/110/856/192/1/1108561921.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BL.DG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049956,
     "wof:geomhash":"cf49a9859d35af783ab1c1f635a87d4f",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561921,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886698,
     "wof:name":"Dahann-i- Ghuri",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/192/5/1108561925.geojson
+++ b/data/110/856/192/5/1108561925.geojson
@@ -122,6 +122,7 @@
         "hasc:id":"AF.KD.DM",
         "wd:id":"Q3012608"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049958,
     "wof:geomhash":"75858abc01826fce336324ef18c29802",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108561925,
-    "wof:lastmodified":1694498102,
+    "wof:lastmodified":1695886728,
     "wof:name":"Daman",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/192/7/1108561927.geojson
+++ b/data/110/856/192/7/1108561927.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PT.DP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049959,
     "wof:geomhash":"9aab7345ea617eb00a50e4f565541d46",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561927,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886698,
     "wof:name":"Dand Patan",
     "wof:parent_id":85667641,
     "wof:placetype":"county",

--- a/data/110/856/192/9/1108561929.geojson
+++ b/data/110/856/192/9/1108561929.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.KR.DA",
         "wd:id":"Q2663252"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049960,
     "wof:geomhash":"ac489cb5732630bc995954a59ac5e59d",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108561929,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886698,
     "wof:name":"Dangam",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/193/1/1108561931.geojson
+++ b/data/110/856/193/1/1108561931.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.DN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049961,
     "wof:geomhash":"bfc3cd2399299f1adfd30e2323a112cf",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561931,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886699,
     "wof:name":"Dara-I-Nur",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/193/3/1108561933.geojson
+++ b/data/110/856/193/3/1108561933.geojson
@@ -117,6 +117,7 @@
         "hasc:id":"AF.KR.DP",
         "wd:id":"Q2663248"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049962,
     "wof:geomhash":"653f48e64002d468326b91ca025eacaf",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108561933,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886699,
     "wof:name":"Dara-I-Pech",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/193/5/1108561935.geojson
+++ b/data/110/856/193/5/1108561935.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.SM.DB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049963,
     "wof:geomhash":"df6a81e322f34c1c2e9b09679ba5047f",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561935,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886699,
     "wof:name":"Dara-I-Sufi Bala",
     "wof:parent_id":85667631,
     "wof:placetype":"county",

--- a/data/110/856/193/7/1108561937.geojson
+++ b/data/110/856/193/7/1108561937.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.SM.DS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049964,
     "wof:geomhash":"98bfb1cf5ad57828a6d2621f1eec951f",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561937,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886699,
     "wof:name":"Dara-I-Sufi Payin",
     "wof:parent_id":85667631,
     "wof:placetype":"county",

--- a/data/110/856/193/9/1108561939.geojson
+++ b/data/110/856/193/9/1108561939.geojson
@@ -78,6 +78,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PJ.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049965,
     "wof:geomhash":"e4dd68d369cde3364815c34080c84e97",
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108561939,
-    "wof:lastmodified":1694497951,
+    "wof:lastmodified":1695886699,
     "wof:name":"Dara",
     "wof:parent_id":1108803081,
     "wof:placetype":"county",

--- a/data/110/856/194/3/1108561943.geojson
+++ b/data/110/856/194/3/1108561943.geojson
@@ -126,6 +126,7 @@
         "hasc:id":"AF.BD.DY",
         "wd:id":"Q2670900"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049966,
     "wof:geomhash":"3fd3960244a1546209889caccc5a24f1",
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108561943,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886614,
     "wof:name":"Darayim",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/194/5/1108561945.geojson
+++ b/data/110/856/194/5/1108561945.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"AF.TK.DA",
         "wd:id":"Q3918446"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049967,
     "wof:geomhash":"df5b4d6dedc0d158aaa7f3925e0192a2",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108561945,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886699,
     "wof:name":"Darqad",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/194/7/1108561947.geojson
+++ b/data/110/856/194/7/1108561947.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"AF.BD.DA",
         "wd:id":"Q2673995"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049968,
     "wof:geomhash":"7038b976d781a599c2f9388e7e80116b",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108561947,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886614,
     "wof:name":"Darwaz",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/194/9/1108561949.geojson
+++ b/data/110/856/194/9/1108561949.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BD.DB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049969,
     "wof:geomhash":"d0ad9afb14198557fa9073b4dd853176",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561949,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886699,
     "wof:name":"Darwazbala",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/195/1/1108561951.geojson
+++ b/data/110/856/195/1/1108561951.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"AF.JW.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049971,
     "wof:geomhash":"9f5ab4214215b2c00818c951ee03bd55",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561951,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886699,
     "wof:name":"Darzab",
     "wof:parent_id":85667513,
     "wof:placetype":"county",

--- a/data/110/856/195/3/1108561953.geojson
+++ b/data/110/856/195/3/1108561953.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KZ.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049972,
     "wof:geomhash":"e91f49cf995feda3afa2a9a2ee7c9843",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1108561953,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886699,
     "wof:name":"Dashte Archi",
     "wof:parent_id":85667585,
     "wof:placetype":"county",

--- a/data/110/856/195/5/1108561955.geojson
+++ b/data/110/856/195/5/1108561955.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.TK.DQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049973,
     "wof:geomhash":"6501c0ceb1fdd35d9a475961706b9ce3",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561955,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886699,
     "wof:name":"Dashti Qala",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/195/7/1108561957.geojson
+++ b/data/110/856/195/7/1108561957.geojson
@@ -83,6 +83,7 @@
         "hasc:id":"AF.LM.DS",
         "wd:id":"Q5242376"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049974,
     "wof:geomhash":"2618d9df2d1549cc53c17b3d0f6ddeae",
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108561957,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886699,
     "wof:name":"Daulatshahi",
     "wof:parent_id":85667617,
     "wof:placetype":"county",

--- a/data/110/856/196/1/1108561961.geojson
+++ b/data/110/856/196/1/1108561961.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GR.DY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049975,
     "wof:geomhash":"1bd8c72e9af5f0ce02125f01cc55d334",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561961,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886700,
     "wof:name":"Dawlat Yar",
     "wof:parent_id":85667519,
     "wof:placetype":"county",

--- a/data/110/856/196/3/1108561963.geojson
+++ b/data/110/856/196/3/1108561963.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BK.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049976,
     "wof:geomhash":"06819c70f3f7ddcc9c845c9e4008c7ea",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561963,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886700,
     "wof:name":"Dawlatabad",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/196/5/1108561965.geojson
+++ b/data/110/856/196/5/1108561965.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.FB.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049977,
     "wof:geomhash":"d4cf7ce4b753f65169f1c75df1f80ef4",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561965,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886700,
     "wof:name":"Dawlatabad",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/196/7/1108561967.geojson
+++ b/data/110/856/196/7/1108561967.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.VR.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049978,
     "wof:geomhash":"60576d46b0646bd8120f84ad73eb86f0",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108561967,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886700,
     "wof:name":"Day Mirdad",
     "wof:parent_id":85667635,
     "wof:placetype":"county",

--- a/data/110/856/196/9/1108561969.geojson
+++ b/data/110/856/196/9/1108561969.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.ZB.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049979,
     "wof:geomhash":"c48c4c6a15a1dc21f9805fd5d08f35c8",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108561969,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886700,
     "wof:name":"Daychopan",
     "wof:parent_id":85667555,
     "wof:placetype":"county",

--- a/data/110/856/197/1/1108561971.geojson
+++ b/data/110/856/197/1/1108561971.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.NG.DL",
         "wd:id":"Q2217876"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049980,
     "wof:geomhash":"60f82d62f76f3ac4a03a95ac8bdd5a10",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108561971,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886700,
     "wof:name":"Deh Bala",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/197/3/1108561973.geojson
+++ b/data/110/856/197/3/1108561973.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KB.DS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049981,
     "wof:geomhash":"f59e8a3792580aaba6ce85e8bcac4c5a",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561973,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886700,
     "wof:name":"Dih Sabz",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/110/856/197/5/1108561975.geojson
+++ b/data/110/856/197/5/1108561975.geojson
@@ -133,6 +133,7 @@
         "hasc:id":"AF.BL.DS",
         "wd:id":"Q2376379"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049983,
     "wof:geomhash":"03390175e7dc68301aee1245b7101657",
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108561975,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886617,
     "wof:name":"Dih Salah",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/197/9/1108561979.geojson
+++ b/data/110/856/197/9/1108561979.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GZ.DI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049984,
     "wof:geomhash":"35619fc4ecb0058c19c08275229adc44",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561979,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886700,
     "wof:name":"Dih Yak",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/198/1/1108561981.geojson
+++ b/data/110/856/198/1/1108561981.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"AF.BK.DI",
         "wd:id":"Q3696070"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049985,
     "wof:geomhash":"aeadf965b457613de1e3ce4ec20f8c5b",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108561981,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886700,
     "wof:name":"Dihdadi",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/198/3/1108561983.geojson
+++ b/data/110/856/198/3/1108561983.geojson
@@ -115,6 +115,7 @@
         "hasc:id":"AF.OZ.DI",
         "wd:id":"Q1183073"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049986,
     "wof:geomhash":"6774f27faba0d4a5c87c4a6cc65e09fd",
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108561983,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886617,
     "wof:name":"Dihrawud",
     "wof:parent_id":85667541,
     "wof:placetype":"county",

--- a/data/110/856/198/5/1108561985.geojson
+++ b/data/110/856/198/5/1108561985.geojson
@@ -82,6 +82,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.DI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049987,
     "wof:geomhash":"2dce42d8cd604aa8a466a791f071bc1a",
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108561985,
-    "wof:lastmodified":1694498102,
+    "wof:lastmodified":1695886728,
     "wof:name":"Dila",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/198/7/1108561987.geojson
+++ b/data/110/856/198/7/1108561987.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NM.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049988,
     "wof:geomhash":"8a31c5aa808332fdfc4db39ba06ee58f",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1108561987,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886700,
     "wof:name":"Dilaram",
     "wof:parent_id":85667537,
     "wof:placetype":"county",

--- a/data/110/856/198/9/1108561989.geojson
+++ b/data/110/856/198/9/1108561989.geojson
@@ -118,6 +118,7 @@
         "hasc:id":"AF.HM.DI",
         "wd:id":"Q2456306"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049989,
     "wof:geomhash":"dd33e66046eba3b3ce9a38b45d4b6125",
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108561989,
-    "wof:lastmodified":1694497952,
+    "wof:lastmodified":1695886700,
     "wof:name":"Dishu",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/110/856/199/1/1108561991.geojson
+++ b/data/110/856/199/1/1108561991.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NR.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049990,
     "wof:geomhash":"cb7238587fab09fa21e410a278527e0f",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561991,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886700,
     "wof:name":"Du Ab",
     "wof:parent_id":85667577,
     "wof:placetype":"county",

--- a/data/110/856/199/3/1108561993.geojson
+++ b/data/110/856/199/3/1108561993.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GR.DL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049991,
     "wof:geomhash":"ad006b97950147fe8315aeade76ae85f",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561993,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886700,
     "wof:name":"Du Layna",
     "wof:parent_id":85667519,
     "wof:placetype":"county",

--- a/data/110/856/199/7/1108561997.geojson
+++ b/data/110/856/199/7/1108561997.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.DB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049992,
     "wof:geomhash":"dca6cf7303dd4422c21c8630a6caa9fd",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108561997,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Dur Baba",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/199/9/1108561999.geojson
+++ b/data/110/856/199/9/1108561999.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BL.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049993,
     "wof:geomhash":"9f3db848839d4a5b2b6eea4568589371",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108561999,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Dushi",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/200/1/1108562001.geojson
+++ b/data/110/856/200/1/1108562001.geojson
@@ -116,6 +116,7 @@
     "wof:concordances":{
         "hasc:id":"AF.FH.FH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049994,
     "wof:geomhash":"bc66095779d3c02bd2dddac33277128c",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108562001,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886729,
     "wof:name":"Farah",
     "wof:parent_id":85667527,
     "wof:placetype":"county",

--- a/data/110/856/200/3/1108562003.geojson
+++ b/data/110/856/200/3/1108562003.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BL.FG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049995,
     "wof:geomhash":"c7520b4f64d8ce4e1c40082b2b0431b5",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562003,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Farang Wa Gharu",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/200/5/1108562005.geojson
+++ b/data/110/856/200/5/1108562005.geojson
@@ -121,6 +121,7 @@
     "wof:concordances":{
         "hasc:id":"AF.TK.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049996,
     "wof:geomhash":"1e21c5c5f4543d7eecda001816bf5aa7",
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108562005,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Farkhar",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/200/7/1108562007.geojson
+++ b/data/110/856/200/7/1108562007.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HR.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049998,
     "wof:geomhash":"432dd9424a6750268723ebba69a532cb",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562007,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Farsi",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/200/9/1108562009.geojson
+++ b/data/110/856/200/9/1108562009.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KB.FS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474049999,
     "wof:geomhash":"7d00bce0713e63930773560c600bcece",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562009,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Farza",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/110/856/201/1/1108562011.geojson
+++ b/data/110/856/201/1/1108562011.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BD.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050001,
     "wof:geomhash":"bf87f586eee84a34b29d91ec95dc1e44",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562011,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Fayzabad",
     "wof:parent_id":85667513,
     "wof:placetype":"county",

--- a/data/110/856/201/5/1108562015.geojson
+++ b/data/110/856/201/5/1108562015.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.SM.FN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050002,
     "wof:geomhash":"048fe56a7b6549f0e0e25568a85a97ee",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562015,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Feroz Nakhchir",
     "wof:parent_id":85667631,
     "wof:placetype":"county",

--- a/data/110/856/201/7/1108562017.geojson
+++ b/data/110/856/201/7/1108562017.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"AF.DK.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050003,
     "wof:geomhash":"7c97d32795f1570a45e16389787bc873",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1108562017,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Gaiti",
     "wof:parent_id":1108803083,
     "wof:placetype":"county",

--- a/data/110/856/201/9/1108562019.geojson
+++ b/data/110/856/201/9/1108562019.geojson
@@ -105,6 +105,7 @@
         "hasc:id":"AF.HM.GA",
         "wd:id":"Q3506581"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050005,
     "wof:geomhash":"9ceefa7307f7215aff52a8e3d5ec6743",
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108562019,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886619,
     "wof:name":"Garmser",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/110/856/202/1/1108562021.geojson
+++ b/data/110/856/202/1/1108562021.geojson
@@ -77,6 +77,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050006,
     "wof:geomhash":"3141e5d83244a32bb347a71ab86b141e",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108562021,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Gayan",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/202/3/1108562023.geojson
+++ b/data/110/856/202/3/1108562023.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GZ.GE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050007,
     "wof:geomhash":"ba9cda43728a80ac515e5fffd6f3f1c5",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562023,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Gelan",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/202/5/1108562025.geojson
+++ b/data/110/856/202/5/1108562025.geojson
@@ -92,6 +92,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KR.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050008,
     "wof:geomhash":"452afbe6d88a90e101ee10169fbe15ae",
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108562025,
-    "wof:lastmodified":1694498102,
+    "wof:lastmodified":1695886728,
     "wof:name":"Ghaziabad",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/202/7/1108562027.geojson
+++ b/data/110/856/202/7/1108562027.geojson
@@ -238,6 +238,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GZ.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050009,
     "wof:geomhash":"3910ceec1b3d37d7074055882403a649",
@@ -250,7 +251,7 @@
         }
     ],
     "wof:id":1108562027,
-    "wof:lastmodified":1694498102,
+    "wof:lastmodified":1695886729,
     "wof:name":"Ghazni",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/202/9/1108562029.geojson
+++ b/data/110/856/202/9/1108562029.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KD.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050010,
     "wof:geomhash":"d7f714fb516c843ec53fc77f2590d7ad",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562029,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886615,
     "wof:name":"Ghorak",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/203/3/1108562033.geojson
+++ b/data/110/856/203/3/1108562033.geojson
@@ -116,6 +116,7 @@
         "hasc:id":"AF.BG.GH",
         "wd:id":"Q2429826"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050011,
     "wof:geomhash":"de48d6142016e81c1dd816659b50ec88",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108562033,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Ghormach",
     "wof:parent_id":85667493,
     "wof:placetype":"county",

--- a/data/110/856/203/5/1108562035.geojson
+++ b/data/110/856/203/5/1108562035.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HR.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050012,
     "wof:geomhash":"a98dfba1394a6662a68a924705bbed63",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562035,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886702,
     "wof:name":"Ghoryan",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/203/7/1108562037.geojson
+++ b/data/110/856/203/7/1108562037.geojson
@@ -112,6 +112,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GZ.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050013,
     "wof:geomhash":"53e8837366b85c67ad90352c79480ce9",
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108562037,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Giro",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/203/9/1108562039.geojson
+++ b/data/110/856/203/9/1108562039.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"AF.DK.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050014,
     "wof:geomhash":"2b02e9c03b67439d9b0cdcaf292262e2",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108562039,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Gizab",
     "wof:parent_id":1108803083,
     "wof:placetype":"county",

--- a/data/110/856/204/1/1108562041.geojson
+++ b/data/110/856/204/1/1108562041.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050016,
     "wof:geomhash":"370cc4627ac97816027d3e14bf775db6",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108562041,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Gomal",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/204/3/1108562043.geojson
+++ b/data/110/856/204/3/1108562043.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"AF.SP.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050017,
     "wof:geomhash":"76bdf3433f5e973daae04354bc0b9d83",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108562043,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886702,
     "wof:name":"Gosfandi",
     "wof:parent_id":85667523,
     "wof:placetype":"county",

--- a/data/110/856/204/5/1108562045.geojson
+++ b/data/110/856/204/5/1108562045.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"AF.NG.GO",
         "wd:id":"Q2217848"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050018,
     "wof:geomhash":"be2f615d4f543c0372974e757f86a9db",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108562045,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886702,
     "wof:name":"Goshta",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/204/7/1108562047.geojson
+++ b/data/110/856/204/7/1108562047.geojson
@@ -117,6 +117,7 @@
         "hasc:id":"AF.FH.GU",
         "wd:id":"Q2537755"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050020,
     "wof:geomhash":"9f16214a6530140e2b46681f3d54c4cb",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108562047,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886615,
     "wof:name":"Gulistan",
     "wof:parent_id":85667527,
     "wof:placetype":"county",

--- a/data/110/856/205/1/1108562051.geojson
+++ b/data/110/856/205/1/1108562051.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HR.GL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050021,
     "wof:geomhash":"e8d955bdf39dedcca6f56b50888ea444",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562051,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886702,
     "wof:name":"Gulran",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/205/3/1108562053.geojson
+++ b/data/110/856/205/3/1108562053.geojson
@@ -79,6 +79,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KT.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050022,
     "wof:geomhash":"47591054e22ca223171f20ffa8e11c1f",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108562053,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886702,
     "wof:name":"Gurbuz",
     "wof:parent_id":85667563,
     "wof:placetype":"county",

--- a/data/110/856/205/5/1108562055.geojson
+++ b/data/110/856/205/5/1108562055.geojson
@@ -108,6 +108,7 @@
         "hasc:id":"AF.FB.DR",
         "wd:id":"Q4907641"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050023,
     "wof:geomhash":"1a98cd3e6fd169bdf997d5b5debdce7d",
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108562055,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886702,
     "wof:name":"Gurziwan",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/205/7/1108562057.geojson
+++ b/data/110/856/205/7/1108562057.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HR.GZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050023,
     "wof:geomhash":"12d6af62f618dd08ab0181fd41d0c237",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562057,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886702,
     "wof:name":"Guzara",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/205/9/1108562059.geojson
+++ b/data/110/856/205/9/1108562059.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BL.GN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050024,
     "wof:geomhash":"0aa643a0349163999ac4c6ec738b8d0e",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562059,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886702,
     "wof:name":"Guzargahi Nur",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/206/1/1108562061.geojson
+++ b/data/110/856/206/1/1108562061.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.TK.HS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050026,
     "wof:geomhash":"7cb7473857bfbfa192e45238b41cc2ee",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562061,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886702,
     "wof:name":"Hazar Sumuch",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/206/3/1108562063.geojson
+++ b/data/110/856/206/3/1108562063.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.SM.HS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050027,
     "wof:geomhash":"55e69b7969728badfd7635d42d2484bc",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562063,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886702,
     "wof:name":"Hazrati Sultan",
     "wof:parent_id":85667631,
     "wof:placetype":"county",

--- a/data/110/856/206/5/1108562065.geojson
+++ b/data/110/856/206/5/1108562065.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"AF.NG.HI",
         "wd:id":"Q3694366"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050028,
     "wof:geomhash":"9f3d8852f14c6fc1f5fc4791ba8037e0",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108562065,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886702,
     "wof:name":"Hesarak",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/206/9/1108562069.geojson
+++ b/data/110/856/206/9/1108562069.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HR.HI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050029,
     "wof:geomhash":"0200c108708411dca19fffc3994dc558",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108562069,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886729,
     "wof:name":"Hirat",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/207/1/1108562071.geojson
+++ b/data/110/856/207/1/1108562071.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.VR.HB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050030,
     "wof:geomhash":"1c314cd60027ef159007375aa44d202d",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562071,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886702,
     "wof:name":"Hisa-I- Awali Bihsud",
     "wof:parent_id":85667635,
     "wof:placetype":"county",

--- a/data/110/856/207/3/1108562073.geojson
+++ b/data/110/856/207/3/1108562073.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KP.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050031,
     "wof:geomhash":"02e58a0fddf1637023dcc4c11d14d125",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562073,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886702,
     "wof:name":"Hisa-i-Awali Kohistan",
     "wof:parent_id":85667609,
     "wof:placetype":"county",

--- a/data/110/856/207/5/1108562075.geojson
+++ b/data/110/856/207/5/1108562075.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KP.PJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050032,
     "wof:geomhash":"53ac0657d5d5cb76419edacf3058ce0f",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562075,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886702,
     "wof:name":"Hisa-i-Duwumi Kohistan",
     "wof:parent_id":85667609,
     "wof:placetype":"county",

--- a/data/110/856/207/7/1108562077.geojson
+++ b/data/110/856/207/7/1108562077.geojson
@@ -114,6 +114,7 @@
         "hasc:id":"AF.KZ.HI",
         "wd:id":"Q1315873"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050033,
     "wof:geomhash":"6fcd941d8fac1c01fdb3fd5aa9d9643f",
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108562077,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886619,
     "wof:name":"Imam Sahib",
     "wof:parent_id":85667585,
     "wof:placetype":"county",

--- a/data/110/856/207/9/1108562079.geojson
+++ b/data/110/856/207/9/1108562079.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HR.IN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050034,
     "wof:geomhash":"1ac08acb9dc98337a453213804ebf996",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562079,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Injil",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/208/1/1108562081.geojson
+++ b/data/110/856/208/1/1108562081.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.TK.IS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050035,
     "wof:geomhash":"622398fb2c7c7fb7d5fd8e2d3c9f9319",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562081,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886702,
     "wof:name":"Ishkamish",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/208/3/1108562083.geojson
+++ b/data/110/856/208/3/1108562083.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"AF.DK.IS",
         "wd:id":"Q6595513"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050037,
     "wof:geomhash":"f448c20deccd19bd027449954aadfd06",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108562083,
-    "wof:lastmodified":1694497950,
+    "wof:lastmodified":1695886696,
     "wof:name":"Ishtarlay",
     "wof:parent_id":1108803083,
     "wof:placetype":"county",

--- a/data/110/856/208/7/1108562087.geojson
+++ b/data/110/856/208/7/1108562087.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"AF.KB.IS",
         "wd:id":"Q1674831"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050038,
     "wof:geomhash":"ac6c7d9dd877b69521f702719af6caec",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108562087,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886702,
     "wof:name":"Istalif",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/110/856/208/9/1108562089.geojson
+++ b/data/110/856/208/9/1108562089.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"AF.VR.JG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050040,
     "wof:geomhash":"c7b93d52e8f3ed741133c8c297e09e34",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108562089,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Jaghatu",
     "wof:parent_id":85667635,
     "wof:placetype":"county",

--- a/data/110/856/209/1/1108562091.geojson
+++ b/data/110/856/209/1/1108562091.geojson
@@ -119,6 +119,7 @@
         "hasc:id":"AF.GZ.JR",
         "wd:id":"Q2724474"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050041,
     "wof:geomhash":"ff0702f51849dda50199bb9c9de0fcc2",
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108562091,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886618,
     "wof:name":"Jaghuri",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/209/3/1108562093.geojson
+++ b/data/110/856/209/3/1108562093.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KT.JM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050042,
     "wof:geomhash":"8de7b9ed5a80be79391af8cb656537c3",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562093,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Jaji Maidan",
     "wof:parent_id":85667563,
     "wof:placetype":"county",

--- a/data/110/856/209/5/1108562095.geojson
+++ b/data/110/856/209/5/1108562095.geojson
@@ -215,6 +215,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050043,
     "wof:geomhash":"262da7dcafe83d3c7f70a622031bcb65",
@@ -227,7 +228,7 @@
         }
     ],
     "wof:id":1108562095,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886619,
     "wof:name":"Jalalabad",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/209/7/1108562097.geojson
+++ b/data/110/856/209/7/1108562097.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"AF.VR.JL",
         "wd:id":"Q1679783"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050044,
     "wof:geomhash":"da807982ad6663a601898e177f98bce5",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108562097,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886619,
     "wof:name":"Jalrez",
     "wof:parent_id":85667635,
     "wof:placetype":"county",

--- a/data/110/856/209/9/1108562099.geojson
+++ b/data/110/856/209/9/1108562099.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.JK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050045,
     "wof:geomhash":"b79cf119cb6e276cb3cbe13ea3a0cbe2",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562099,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Jani Khail",
     "wof:parent_id":85667641,
     "wof:placetype":"county",

--- a/data/110/856/210/1/1108562101.geojson
+++ b/data/110/856/210/1/1108562101.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PT.JK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050046,
     "wof:geomhash":"8214bb7413b6213b2c427cc2208f1584",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562101,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Jani Khel",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/210/5/1108562105.geojson
+++ b/data/110/856/210/5/1108562105.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"AF.BG.JA",
         "wd:id":"Q2429284"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050047,
     "wof:geomhash":"66193229b04866680be8a78a01e8cd4e",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108562105,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Jawand",
     "wof:parent_id":85667493,
     "wof:placetype":"county",

--- a/data/110/856/210/7/1108562107.geojson
+++ b/data/110/856/210/7/1108562107.geojson
@@ -128,6 +128,7 @@
         "hasc:id":"AF.BD.JU",
         "wd:id":"Q2670928"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050048,
     "wof:geomhash":"5c0520165aecdcd7c99706dc28c6685d",
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108562107,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886615,
     "wof:name":"Jurm",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/210/9/1108562109.geojson
+++ b/data/110/856/210/9/1108562109.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"AF.BM.KA",
         "wd:id":"Q2322035"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050049,
     "wof:geomhash":"a889b05b4539f73c61332872a765f92d",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108562109,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886615,
     "wof:name":"Kahmard",
     "wof:parent_id":85667503,
     "wof:placetype":"county",

--- a/data/110/856/211/1/1108562111.geojson
+++ b/data/110/856/211/1/1108562111.geojson
@@ -119,6 +119,7 @@
         "hasc:id":"AF.HM.KA",
         "wd:id":"Q222963"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050050,
     "wof:geomhash":"7797e8cfd7c3bb9c17b775c53ccb75e3",
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108562111,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Kajaki",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/110/856/211/3/1108562113.geojson
+++ b/data/110/856/211/3/1108562113.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.DK.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050051,
     "wof:geomhash":"ddc3e3a2b9a97ce68eb3ffe941cd1906",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562113,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Kajran",
     "wof:parent_id":1108803083,
     "wof:placetype":"county",

--- a/data/110/856/211/5/1108562115.geojson
+++ b/data/110/856/211/5/1108562115.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.ZB.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050052,
     "wof:geomhash":"ac687fd3f87be337643f09bc9ac7909e",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562115,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Kakar",
     "wof:parent_id":85667555,
     "wof:placetype":"county",

--- a/data/110/856/211/7/1108562117.geojson
+++ b/data/110/856/211/7/1108562117.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KB.KL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050053,
     "wof:geomhash":"e17666f826efdc70b2cc070a264af644",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108562117,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Kalakan",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/110/856/211/9/1108562119.geojson
+++ b/data/110/856/211/9/1108562119.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BK.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050054,
     "wof:geomhash":"98897fdebbd42844ab8e61d43909ff2a",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108562119,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Kaldar",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/212/3/1108562123.geojson
+++ b/data/110/856/212/3/1108562123.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.TK.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050055,
     "wof:geomhash":"c855213ee0cd94bbff5e86c59a59d3f7",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562123,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Kalfagan",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/212/5/1108562125.geojson
+++ b/data/110/856/212/5/1108562125.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"AF.NG.KA",
         "wd:id":"Q3503777"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050056,
     "wof:geomhash":"da3aefc637ceb322074ad42190c20c10",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108562125,
-    "wof:lastmodified":1694498102,
+    "wof:lastmodified":1695886729,
     "wof:name":"Kama",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/212/7/1108562127.geojson
+++ b/data/110/856/212/7/1108562127.geojson
@@ -119,6 +119,7 @@
         "hasc:id":"AF.NR.KA",
         "wd:id":"Q1722904"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050057,
     "wof:geomhash":"eb5c3cbf3f7b9bc54ca26589c1ea8c9f",
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108562127,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886617,
     "wof:name":"Kamdesh",
     "wof:parent_id":85667577,
     "wof:placetype":"county",

--- a/data/110/856/212/9/1108562129.geojson
+++ b/data/110/856/212/9/1108562129.geojson
@@ -94,6 +94,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NM.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050059,
     "wof:geomhash":"1d51718d7c597c15ea5e049b846a613b",
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108562129,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886617,
     "wof:name":"Kang",
     "wof:parent_id":85667537,
     "wof:placetype":"county",

--- a/data/110/856/213/1/1108562131.geojson
+++ b/data/110/856/213/1/1108562131.geojson
@@ -79,6 +79,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HR.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050060,
     "wof:geomhash":"a171bd9ce1e6d078137bf914eeea1c54",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108562131,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Karukh",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/213/3/1108562133.geojson
+++ b/data/110/856/213/3/1108562133.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"AF.DK.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050061,
     "wof:geomhash":"4e6e0552ced8c1f5a0182f6568a342ce",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108562133,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Khadir",
     "wof:parent_id":1108803083,
     "wof:placetype":"county",

--- a/data/110/856/213/5/1108562135.geojson
+++ b/data/110/856/213/5/1108562135.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KB.KJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050062,
     "wof:geomhash":"b697a5b53c3e59d9ab4810a2ac77b29a",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562135,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Khaki Jabbar",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/110/856/213/7/1108562137.geojson
+++ b/data/110/856/213/7/1108562137.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.FH.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050064,
     "wof:geomhash":"f538cd93624f27810814c1d9e977b17b",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562137,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886704,
     "wof:name":"Khaki Safed",
     "wof:parent_id":85667527,
     "wof:placetype":"county",

--- a/data/110/856/214/1/1108562141.geojson
+++ b/data/110/856/214/1/1108562141.geojson
@@ -122,6 +122,7 @@
         "hasc:id":"AF.KD.KH",
         "wd:id":"Q2670922"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050065,
     "wof:geomhash":"ae54874de33696b85a87c5d2ef174cef",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108562141,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886618,
     "wof:name":"Khakrez",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/214/3/1108562143.geojson
+++ b/data/110/856/214/3/1108562143.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.JW.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050066,
     "wof:geomhash":"b5221a2e5dc77d063b4709aa39fce51c",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562143,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886704,
     "wof:name":"Kham Ab",
     "wof:parent_id":85667513,
     "wof:placetype":"county",

--- a/data/110/856/214/5/1108562145.geojson
+++ b/data/110/856/214/5/1108562145.geojson
@@ -98,6 +98,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KZ.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050067,
     "wof:geomhash":"4c28123fc64057691bb9c5160f8f8d1d",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108562145,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886618,
     "wof:name":"Khanabad",
     "wof:parent_id":85667585,
     "wof:placetype":"county",

--- a/data/110/856/214/7/1108562147.geojson
+++ b/data/110/856/214/7/1108562147.geojson
@@ -117,6 +117,7 @@
         "hasc:id":"AF.FB.KC",
         "wd:id":"Q3694326"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050068,
     "wof:geomhash":"bb2f247df0b9c7f1f83bb3fb8c8c605f",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108562147,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886704,
     "wof:name":"Khani Chahar Bagh",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/214/9/1108562149.geojson
+++ b/data/110/856/214/9/1108562149.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"AF.JW.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050069,
     "wof:geomhash":"2ad279baa822704d5cd4cf57de5bbaf0",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108562149,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886704,
     "wof:name":"Khaniqa",
     "wof:parent_id":85667513,
     "wof:placetype":"county",

--- a/data/110/856/215/1/1108562151.geojson
+++ b/data/110/856/215/1/1108562151.geojson
@@ -108,6 +108,7 @@
         "hasc:id":"AF.LW.KW",
         "wd:id":"Q2215285"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050070,
     "wof:geomhash":"7fd97280070f814512e90a32bf53e36c",
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108562151,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886704,
     "wof:name":"Kharwar",
     "wof:parent_id":85667623,
     "wof:placetype":"county",

--- a/data/110/856/215/3/1108562153.geojson
+++ b/data/110/856/215/3/1108562153.geojson
@@ -105,6 +105,7 @@
         "hasc:id":"AF.KR.KK",
         "wd:id":"Q2665194"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050071,
     "wof:geomhash":"c13afe862749d1400fbff077ab131cc3",
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108562153,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886704,
     "wof:name":"Khas Kunar",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/215/5/1108562155.geojson
+++ b/data/110/856/215/5/1108562155.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.OZ.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050072,
     "wof:geomhash":"e4bfe2f15abdaec9aedda5f3c5f071e8",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562155,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886704,
     "wof:name":"Khas Uruzgan",
     "wof:parent_id":85667541,
     "wof:placetype":"county",

--- a/data/110/856/215/9/1108562159.geojson
+++ b/data/110/856/215/9/1108562159.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NM.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050073,
     "wof:geomhash":"087c7bbccaebca7cdd9bb3897bdd8a46",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562159,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886704,
     "wof:name":"Khash Rod",
     "wof:parent_id":85667537,
     "wof:placetype":"county",

--- a/data/110/856/216/1/1108562161.geojson
+++ b/data/110/856/216/1/1108562161.geojson
@@ -86,6 +86,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BD.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050074,
     "wof:geomhash":"e19f359c2dff4777e3503c994061912d",
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108562161,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886614,
     "wof:name":"Khash",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/216/3/1108562163.geojson
+++ b/data/110/856/216/3/1108562163.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PJ.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050075,
     "wof:geomhash":"1d7e948973e0de7dcf51a58088360c66",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562163,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886704,
     "wof:name":"Khenj (Hese- Awal)",
     "wof:parent_id":1108803081,
     "wof:placetype":"county",

--- a/data/110/856/216/5/1108562165.geojson
+++ b/data/110/856/216/5/1108562165.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BL.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050076,
     "wof:geomhash":"405ead705a44a377503a66a224b351dc",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562165,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886704,
     "wof:name":"Khinjan",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/216/7/1108562167.geojson
+++ b/data/110/856/216/7/1108562167.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050077,
     "wof:geomhash":"bd16df5399c64c93dc685bf00559bfbc",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562167,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886704,
     "wof:name":"Khogayani",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/216/9/1108562169.geojson
+++ b/data/110/856/216/9/1108562169.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.LW.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050078,
     "wof:geomhash":"bafe860a9093e382c7071f669eca0867",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562169,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886704,
     "wof:name":"Khoshi",
     "wof:parent_id":85667623,
     "wof:placetype":"county",

--- a/data/110/856/217/1/1108562171.geojson
+++ b/data/110/856/217/1/1108562171.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BL.KF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050079,
     "wof:geomhash":"6bbbaa0d47a7219f9c6820aafeb0929b",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562171,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886704,
     "wof:name":"Khost Wa Firing",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/217/3/1108562173.geojson
+++ b/data/110/856/217/3/1108562173.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KT.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050080,
     "wof:geomhash":"65fc1df2b5bc71f75b7323d89523a885",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1108562173,
-    "wof:lastmodified":1694639716,
+    "wof:lastmodified":1695886704,
     "wof:name":"Khost",
     "wof:parent_id":85667563,
     "wof:placetype":"county",

--- a/data/110/856/217/7/1108562177.geojson
+++ b/data/110/856/217/7/1108562177.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BK.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050081,
     "wof:geomhash":"b8c78c05a264b88d93cb5e9719955c96",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562177,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886705,
     "wof:name":"Khulm",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/217/9/1108562179.geojson
+++ b/data/110/856/217/9/1108562179.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.SM.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050082,
     "wof:geomhash":"8754fbad9b1ced3a0184f801a7247af1",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562179,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886705,
     "wof:name":"Khuram Wa Sarbagh",
     "wof:parent_id":85667631,
     "wof:placetype":"county",

--- a/data/110/856/218/1/1108562181.geojson
+++ b/data/110/856/218/1/1108562181.geojson
@@ -131,6 +131,7 @@
         "hasc:id":"AF.BD.KW",
         "wd:id":"Q2673868"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050083,
     "wof:geomhash":"35a492df511e3806048a49fd1ae8c3b3",
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108562181,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886614,
     "wof:name":"Khwahan",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/218/3/1108562183.geojson
+++ b/data/110/856/218/3/1108562183.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.TK.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050084,
     "wof:geomhash":"107af0f2902899bf62f7f5c89b9260cc",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562183,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886705,
     "wof:name":"Khwaja Bahawuddin",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/218/5/1108562185.geojson
+++ b/data/110/856/218/5/1108562185.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"AF.JW.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050085,
     "wof:geomhash":"393c0ea0757798c596de0e9591c755f6",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108562185,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886705,
     "wof:name":"Khwaja Du Koh",
     "wof:parent_id":85667513,
     "wof:placetype":"county",

--- a/data/110/856/218/7/1108562187.geojson
+++ b/data/110/856/218/7/1108562187.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.TK.KG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050086,
     "wof:geomhash":"7b66a65e6874cc8daba2106e7d1e053c",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562187,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886705,
     "wof:name":"Khwaja Ghar",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/218/9/1108562189.geojson
+++ b/data/110/856/218/9/1108562189.geojson
@@ -111,6 +111,7 @@
         "hasc:id":"AF.BL.KW",
         "wd:id":"Q3696090"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050088,
     "wof:geomhash":"13af653a0c4d23d9dc3002b77999029f",
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108562189,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886705,
     "wof:name":"Khwaja Hijran (Jilga Nahrin)",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/219/1/1108562191.geojson
+++ b/data/110/856/219/1/1108562191.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.FB.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050088,
     "wof:geomhash":"bdf57563e1486efbccdd766da066c679",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562191,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886705,
     "wof:name":"Khwaja Sabz Posh",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/219/5/1108562195.geojson
+++ b/data/110/856/219/5/1108562195.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GZ.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050090,
     "wof:geomhash":"7036677982cef6d57f46ad191e30af85",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108562195,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886705,
     "wof:name":"Khwaja Umari",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/219/7/1108562197.geojson
+++ b/data/110/856/219/7/1108562197.geojson
@@ -125,6 +125,7 @@
         "hasc:id":"AF.BD.KI",
         "wd:id":"Q2879146"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050091,
     "wof:geomhash":"800f29a95dfcc2e4c0847f857af105ff",
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108562197,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886615,
     "wof:name":"Kishim",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/219/9/1108562199.geojson
+++ b/data/110/856/219/9/1108562199.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"AF.BK.KI",
         "wd:id":"Q3694263"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050092,
     "wof:geomhash":"d4efaf5bda1eddaca2aede9a6b064114",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108562199,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886705,
     "wof:name":"Kishindih",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/220/1/1108562201.geojson
+++ b/data/110/856/220/1/1108562201.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.KP.KB",
         "wd:id":"Q3694430"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050093,
     "wof:geomhash":"ed6c467f705e315ad8d1558442650d21",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108562201,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886705,
     "wof:name":"Koh Band",
     "wof:parent_id":85667609,
     "wof:placetype":"county",

--- a/data/110/856/220/3/1108562203.geojson
+++ b/data/110/856/220/3/1108562203.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PV.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050094,
     "wof:geomhash":"b87c159c6d5c0b086c9be09c6461593e",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562203,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886705,
     "wof:name":"Kohi Safi",
     "wof:parent_id":85667627,
     "wof:placetype":"county",

--- a/data/110/856/220/5/1108562205.geojson
+++ b/data/110/856/220/5/1108562205.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"AF.SP.KO",
         "wd:id":"Q3696160"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050095,
     "wof:geomhash":"6bb81f9cc4c2c2ea51f102315bc58d6d",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108562205,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886706,
     "wof:name":"Kohistanat",
     "wof:parent_id":85667523,
     "wof:placetype":"county",

--- a/data/110/856/220/7/1108562207.geojson
+++ b/data/110/856/220/7/1108562207.geojson
@@ -83,6 +83,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BD.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050096,
     "wof:geomhash":"aeead7d5f1fa767c7f0a784bfacb0d76",
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108562207,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886706,
     "wof:name":"Kohistan",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/220/9/1108562209.geojson
+++ b/data/110/856/220/9/1108562209.geojson
@@ -83,6 +83,7 @@
     "wof:concordances":{
         "hasc:id":"AF.FB.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050097,
     "wof:geomhash":"a45b9432f01211f2ca6eca900a43545a",
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108562209,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886706,
     "wof:name":"Kohistan",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/221/3/1108562213.geojson
+++ b/data/110/856/221/3/1108562213.geojson
@@ -114,6 +114,7 @@
         "hasc:id":"AF.HR.KN",
         "wd:id":"Q513241"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050098,
     "wof:geomhash":"877978e889740b6c9f7802e10852bb5c",
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108562213,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886706,
     "wof:name":"Kohsan",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/221/5/1108562215.geojson
+++ b/data/110/856/221/5/1108562215.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HR.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050099,
     "wof:geomhash":"b4defbfb9ca9bccd087d422f21624101",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562215,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886706,
     "wof:name":"Koshk",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/221/7/1108562217.geojson
+++ b/data/110/856/221/7/1108562217.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HR.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050100,
     "wof:geomhash":"d968e9fcc05da523d579bf1a231824be",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562217,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886706,
     "wof:name":"Koshki Kohna",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/221/9/1108562219.geojson
+++ b/data/110/856/221/9/1108562219.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BD.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050102,
     "wof:geomhash":"eddda4e4f5157d586051ffc509a7c3c4",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562219,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886706,
     "wof:name":"Kuf Ab",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/222/1/1108562221.geojson
+++ b/data/110/856/222/1/1108562221.geojson
@@ -126,6 +126,7 @@
         "hasc:id":"AF.BD.KM",
         "wd:id":"Q1792940"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050103,
     "wof:geomhash":"7347ca3f644943b76600716b8cf8891b",
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108562221,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886618,
     "wof:name":"Kuran Wa Munjan",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/222/3/1108562223.geojson
+++ b/data/110/856/222/3/1108562223.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050104,
     "wof:geomhash":"6d24791c991de2d804c99bf3a3860405",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562223,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886706,
     "wof:name":"Kuz Kunar",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/222/5/1108562225.geojson
+++ b/data/110/856/222/5/1108562225.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PT.LM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050105,
     "wof:geomhash":"c9ee5383a9a29e73d3c0f4de3dac00c3",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562225,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886706,
     "wof:name":"Laja Ahmad Khail",
     "wof:parent_id":85667641,
     "wof:placetype":"county",

--- a/data/110/856/222/7/1108562227.geojson
+++ b/data/110/856/222/7/1108562227.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.LP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050106,
     "wof:geomhash":"ba891a39391f2c5913d886962bfb2223",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562227,
-    "wof:lastmodified":1694497955,
+    "wof:lastmodified":1695886707,
     "wof:name":"Lal Por",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/223/1/1108562231.geojson
+++ b/data/110/856/223/1/1108562231.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GR.LS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050107,
     "wof:geomhash":"6d18dda8a1a915d458fc34093284e3a6",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562231,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Lal Wa Sarjangal",
     "wof:parent_id":85667519,
     "wof:placetype":"county",

--- a/data/110/856/223/3/1108562233.geojson
+++ b/data/110/856/223/3/1108562233.geojson
@@ -112,6 +112,7 @@
         "hasc:id":"AF.FH.LJ",
         "wd:id":"Q2537782"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050108,
     "wof:geomhash":"8b6c617264954c6b67862e1ea3f02109",
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108562233,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886617,
     "wof:name":"Lash Wa Juwayn",
     "wof:parent_id":85667527,
     "wof:placetype":"county",

--- a/data/110/856/223/5/1108562235.geojson
+++ b/data/110/856/223/5/1108562235.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KP.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050110,
     "wof:geomhash":"585e5ce504515581005863ed86e3f1b2",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562235,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Mahmudi Raqi",
     "wof:parent_id":85667609,
     "wof:placetype":"county",

--- a/data/110/856/223/7/1108562237.geojson
+++ b/data/110/856/223/7/1108562237.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GZ.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050111,
     "wof:geomhash":"518bfb5063c656b3b8c83b9bf4d783d8",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562237,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Malistan",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/223/9/1108562239.geojson
+++ b/data/110/856/223/9/1108562239.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KT.MZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050112,
     "wof:geomhash":"de229734ce6f21624a429a0d7b69e42f",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562239,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Mando Zayi",
     "wof:parent_id":85667563,
     "wof:placetype":"county",

--- a/data/110/856/224/1/1108562241.geojson
+++ b/data/110/856/224/1/1108562241.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"AF.NR.MA",
         "wd:id":"Q1889040"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050113,
     "wof:geomhash":"e84341796ace2d3c9f40ee897ffc78da",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108562241,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Mandol",
     "wof:parent_id":85667577,
     "wof:placetype":"county",

--- a/data/110/856/224/3/1108562243.geojson
+++ b/data/110/856/224/3/1108562243.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.JW.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050114,
     "wof:geomhash":"be49f938b4f727985ddebb09c15a9f23",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562243,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Mangajek",
     "wof:parent_id":85667513,
     "wof:placetype":"county",

--- a/data/110/856/224/5/1108562245.geojson
+++ b/data/110/856/224/5/1108562245.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KR.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050116,
     "wof:geomhash":"25ba6a2814ed0446ffccbe71a30845e9",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562245,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Marawara",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/224/9/1108562249.geojson
+++ b/data/110/856/224/9/1108562249.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.JW.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050117,
     "wof:geomhash":"6ea7d8c6131014413f770a3084aca91f",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562249,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Mardyan",
     "wof:parent_id":85667513,
     "wof:placetype":"county",

--- a/data/110/856/225/1/1108562251.geojson
+++ b/data/110/856/225/1/1108562251.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.VR.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050118,
     "wof:geomhash":"54eec37bdcfdb1e5ed7bd9c9a054eff8",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562251,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Markazi Bihsud",
     "wof:parent_id":85667635,
     "wof:placetype":"county",

--- a/data/110/856/225/3/1108562253.geojson
+++ b/data/110/856/225/3/1108562253.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BK.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050119,
     "wof:geomhash":"5426f3499635e87f86ebe55323558840",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562253,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Marmul",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/225/5/1108562255.geojson
+++ b/data/110/856/225/5/1108562255.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KD.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050120,
     "wof:geomhash":"459c9e1e7a7ca0ec961eeebfcd466ffc",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108562255,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886618,
     "wof:name":"Maruf",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/225/7/1108562257.geojson
+++ b/data/110/856/225/7/1108562257.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050121,
     "wof:geomhash":"84a89a250ba9b831ace8dd54ec2ff007",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562257,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Mata Khan",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/225/9/1108562259.geojson
+++ b/data/110/856/225/9/1108562259.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.VR.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050122,
     "wof:geomhash":"90950a76e089c1bd69b0db5a015f406e",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562259,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Maydan Shahr",
     "wof:parent_id":85667635,
     "wof:placetype":"county",

--- a/data/110/856/226/1/1108562261.geojson
+++ b/data/110/856/226/1/1108562261.geojson
@@ -173,6 +173,7 @@
     "wof:concordances":{
         "hasc:id":"AF.FB.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050123,
     "wof:geomhash":"396dc98d5e05672270a2fd146220f076",
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1108562261,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886615,
     "wof:name":"Maymana",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/226/3/1108562263.geojson
+++ b/data/110/856/226/3/1108562263.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KD.MY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050124,
     "wof:geomhash":"e91a9667e77298fe1fa8a42eeaef4a88",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562263,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Maywand",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/226/7/1108562267.geojson
+++ b/data/110/856/226/7/1108562267.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BK.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050125,
     "wof:geomhash":"4f464df7eb611473edae83733fe076f5",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562267,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886707,
     "wof:name":"Mazari Sharif",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/226/9/1108562269.geojson
+++ b/data/110/856/226/9/1108562269.geojson
@@ -116,6 +116,7 @@
         "hasc:id":"AF.LA.MI",
         "wd:id":"Q1229983"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050127,
     "wof:geomhash":"3aedca261e26bb20d9dcc502999c46e7",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108562269,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886708,
     "wof:name":"Mihtarlam",
     "wof:parent_id":85667617,
     "wof:placetype":"county",

--- a/data/110/856/227/1/1108562271.geojson
+++ b/data/110/856/227/1/1108562271.geojson
@@ -77,6 +77,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KB.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050128,
     "wof:geomhash":"0268622e487f4a01558424be7b75db3b",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108562271,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886708,
     "wof:name":"Mir Bacha Kot",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/110/856/227/3/1108562273.geojson
+++ b/data/110/856/227/3/1108562273.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"AF.DK.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050129,
     "wof:geomhash":"eba8b9cb68b1f40ca218f23de8c0b1a5",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108562273,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886708,
     "wof:name":"Miramor",
     "wof:parent_id":1108803083,
     "wof:placetype":"county",

--- a/data/110/856/227/5/1108562275.geojson
+++ b/data/110/856/227/5/1108562275.geojson
@@ -115,6 +115,7 @@
         "hasc:id":"AF.KD.MN",
         "wd:id":"Q2669304"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050130,
     "wof:geomhash":"ecc6e90f169715d5d27ea779c9173a4b",
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108562275,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886614,
     "wof:name":"Miya Nishin",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/227/7/1108562277.geojson
+++ b/data/110/856/227/7/1108562277.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.ZB.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050131,
     "wof:geomhash":"182a5670ce06e9465cf9b21b6c3f352d",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562277,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886708,
     "wof:name":"Mizan",
     "wof:parent_id":85667555,
     "wof:placetype":"county",

--- a/data/110/856/227/9/1108562279.geojson
+++ b/data/110/856/227/9/1108562279.geojson
@@ -105,6 +105,7 @@
         "hasc:id":"AF.LW.MA",
         "wd:id":"Q1889696"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050132,
     "wof:geomhash":"32f6c58ef665f8657f0b7926dc48129a",
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108562279,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886708,
     "wof:name":"Mohammad Agha",
     "wof:parent_id":85667623,
     "wof:placetype":"county",

--- a/data/110/856/228/1/1108562281.geojson
+++ b/data/110/856/228/1/1108562281.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KT.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050133,
     "wof:geomhash":"1a45789692c8d13d0b575006c26d62b8",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562281,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886708,
     "wof:name":"Mosa Khail",
     "wof:parent_id":85667563,
     "wof:placetype":"county",

--- a/data/110/856/228/5/1108562285.geojson
+++ b/data/110/856/228/5/1108562285.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050134,
     "wof:geomhash":"335648037491bdd32c56c6653beb98aa",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562285,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886708,
     "wof:name":"Muhmand Dara",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/228/7/1108562287.geojson
+++ b/data/110/856/228/7/1108562287.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.BG.MQ",
         "wd:id":"Q2711334"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050135,
     "wof:geomhash":"4dae8ef0e5095e9a09a97abfdca47d8e",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108562287,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886708,
     "wof:name":"Muqur",
     "wof:parent_id":85667493,
     "wof:placetype":"county",

--- a/data/110/856/228/9/1108562289.geojson
+++ b/data/110/856/228/9/1108562289.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"AF.GZ.MU",
         "wd:id":"Q4808934"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050136,
     "wof:geomhash":"ff173dcd9685f200cc32d1287ebdf049",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108562289,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886708,
     "wof:name":"Muqur",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/229/1/1108562291.geojson
+++ b/data/110/856/229/1/1108562291.geojson
@@ -89,6 +89,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HM.MQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050137,
     "wof:geomhash":"8e02f43a28d7b7103a8ab866efa29504",
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108562291,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886708,
     "wof:name":"Musa Qala",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/110/856/229/3/1108562293.geojson
+++ b/data/110/856/229/3/1108562293.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KB.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050138,
     "wof:geomhash":"eb1cf07b7952d39a764ec34e0b80d536",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562293,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886708,
     "wof:name":"Musayi",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/110/856/229/5/1108562295.geojson
+++ b/data/110/856/229/5/1108562295.geojson
@@ -120,6 +120,7 @@
         "hasc:id":"AF.HM.NA",
         "wd:id":"Q477326"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050139,
     "wof:geomhash":"eede431a633964f99212630e8e350b2a",
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108562295,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886708,
     "wof:name":"Nad Ali",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/110/856/229/7/1108562297.geojson
+++ b/data/110/856/229/7/1108562297.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KT.NS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050140,
     "wof:geomhash":"e9d0fa19e229e6b8ea24ccfa5758189c",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562297,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886709,
     "wof:name":"Nadir Shah Kot",
     "wof:parent_id":85667563,
     "wof:placetype":"county",

--- a/data/110/856/229/9/1108562299.geojson
+++ b/data/110/856/229/9/1108562299.geojson
@@ -82,6 +82,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BL.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050142,
     "wof:geomhash":"66ba96d0070d154ea5a3f99e3fd83b75",
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108562299,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886709,
     "wof:name":"Nahrin",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/230/3/1108562303.geojson
+++ b/data/110/856/230/3/1108562303.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.TK.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050143,
     "wof:geomhash":"a445326578fe52208c3f2f072338d3a4",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562303,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886709,
     "wof:name":"Namak Ab",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/230/5/1108562305.geojson
+++ b/data/110/856/230/5/1108562305.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KR.NB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050144,
     "wof:geomhash":"582b6b28d5be9a67a7e4035618a81f11",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562305,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886709,
     "wof:name":"Narang",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/230/7/1108562307.geojson
+++ b/data/110/856/230/7/1108562307.geojson
@@ -108,6 +108,7 @@
         "hasc:id":"AF.KR.NA",
         "wd:id":"Q2663271"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050145,
     "wof:geomhash":"92f174d85d939159fb36e0dec676122e",
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108562307,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886709,
     "wof:name":"Nari",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/230/9/1108562309.geojson
+++ b/data/110/856/230/9/1108562309.geojson
@@ -122,6 +122,7 @@
         "hasc:id":"AF.ZB.NB",
         "wd:id":"Q2673982"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050147,
     "wof:geomhash":"d11d68d160fe04ff25a637f9a6c4b8ff",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108562309,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886709,
     "wof:name":"Naw Bahar",
     "wof:parent_id":85667555,
     "wof:placetype":"county",

--- a/data/110/856/231/1/1108562311.geojson
+++ b/data/110/856/231/1/1108562311.geojson
@@ -120,6 +120,7 @@
         "hasc:id":"AF.HM.NZ",
         "wd:id":"Q2456330"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050148,
     "wof:geomhash":"2f4dfbc7c2c2a288a01b0ad27ad84442",
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108562311,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886709,
     "wof:name":"Naw Zad",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/110/856/231/3/1108562313.geojson
+++ b/data/110/856/231/3/1108562313.geojson
@@ -121,6 +121,7 @@
         "hasc:id":"AF.HM.NB",
         "wd:id":"Q477326"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050149,
     "wof:geomhash":"d699d0db86cacaad7f86cb76e44304a1",
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108562313,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886709,
     "wof:name":"Nawa-I- Barak Zayi",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/110/856/231/5/1108562315.geojson
+++ b/data/110/856/231/5/1108562315.geojson
@@ -122,6 +122,7 @@
         "hasc:id":"AF.GZ.NA",
         "wd:id":"Q2673982"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050150,
     "wof:geomhash":"8e9f64a8929b0bf6310a77235e81ab2a",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108562315,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886709,
     "wof:name":"Nawa",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/231/7/1108562317.geojson
+++ b/data/110/856/231/7/1108562317.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GZ.NR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050151,
     "wof:geomhash":"d510ac253cfd0d2e609a78d94fe7a035",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562317,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886709,
     "wof:name":"Nawur",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/232/1/1108562321.geojson
+++ b/data/110/856/232/1/1108562321.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050152,
     "wof:geomhash":"ac900db86008f2b251e3cdb556fbb0ed",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562321,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886709,
     "wof:name":"Nazyan",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/232/3/1108562323.geojson
+++ b/data/110/856/232/3/1108562323.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KD.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050153,
     "wof:geomhash":"b7038a93e047d35a7d62736ceb92ea67",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562323,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Nesh",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/232/5/1108562325.geojson
+++ b/data/110/856/232/5/1108562325.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KP.NI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050154,
     "wof:geomhash":"df9969a8c7387636bfc4dd99522b534a",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108562325,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886615,
     "wof:name":"Nijrab",
     "wof:parent_id":85667609,
     "wof:placetype":"county",

--- a/data/110/856/232/7/1108562327.geojson
+++ b/data/110/856/232/7/1108562327.geojson
@@ -102,6 +102,7 @@
         "hasc:id":"AF.PK.NI",
         "wd:id":"Q1650486"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050155,
     "wof:geomhash":"bd3fde10a351156c428b0c18b369f075",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108562327,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Nika",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/232/9/1108562329.geojson
+++ b/data/110/856/232/9/1108562329.geojson
@@ -109,6 +109,7 @@
         "hasc:id":"AF.DK.NI",
         "wd:id":"Q3218967"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050156,
     "wof:geomhash":"7bf65b62ed14db9456d0ba6bb4452e68",
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108562329,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Nili",
     "wof:parent_id":1108803083,
     "wof:placetype":"county",

--- a/data/110/856/233/1/1108562331.geojson
+++ b/data/110/856/233/1/1108562331.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.VR.NI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050157,
     "wof:geomhash":"c7a7eda308ecf1a6504c7c5a895df595",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562331,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Nirkh",
     "wof:parent_id":85667635,
     "wof:placetype":"county",

--- a/data/110/856/233/3/1108562333.geojson
+++ b/data/110/856/233/3/1108562333.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KR.NU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050158,
     "wof:geomhash":"e9df80289ea17841d7c567155b9dd1a5",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562333,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Nurgal",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/233/5/1108562335.geojson
+++ b/data/110/856/233/5/1108562335.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"AF.NR.NG",
         "wd:id":"Q3696055"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050159,
     "wof:geomhash":"5906f1d55e5e1226c3abd07ed758ccef",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108562335,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Nurgaram",
     "wof:parent_id":85667577,
     "wof:placetype":"county",

--- a/data/110/856/233/9/1108562339.geojson
+++ b/data/110/856/233/9/1108562339.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HR.OB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050160,
     "wof:geomhash":"62581438bace6e82cf0dfc1c6dbb7717",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562339,
-    "wof:lastmodified":1694497950,
+    "wof:lastmodified":1695886696,
     "wof:name":"Obe",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/234/1/1108562341.geojson
+++ b/data/110/856/234/1/1108562341.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.OM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050161,
     "wof:geomhash":"0446add65d0e5838ecd4271c271e69d9",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562341,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Omna",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/234/3/1108562343.geojson
+++ b/data/110/856/234/3/1108562343.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050162,
     "wof:geomhash":"dd237f8d9356f61f563874f0c24dbc29",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562343,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Pachier Agam",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/234/5/1108562345.geojson
+++ b/data/110/856/234/5/1108562345.geojson
@@ -116,6 +116,7 @@
         "hasc:id":"AF.KB.PA",
         "wd:id":"Q3696078"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050163,
     "wof:geomhash":"4ac47c6ae41379b10847eba95e66d7ce",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108562345,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Paghman",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/110/856/234/7/1108562347.geojson
+++ b/data/110/856/234/7/1108562347.geojson
@@ -119,6 +119,7 @@
         "hasc:id":"AF.BM.PA",
         "wd:id":"Q2321884"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050164,
     "wof:geomhash":"f583d150b6c94e17fce067e37382c696",
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108562347,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Panjab",
     "wof:parent_id":85667503,
     "wof:placetype":"county",

--- a/data/110/856/234/9/1108562349.geojson
+++ b/data/110/856/234/9/1108562349.geojson
@@ -98,6 +98,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KO.WM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050165,
     "wof:geomhash":"f9196d9cbadc1813e4d5bbb992ef9037",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108562349,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Parun",
     "wof:parent_id":85667577,
     "wof:placetype":"county",

--- a/data/110/856/235/1/1108562351.geojson
+++ b/data/110/856/235/1/1108562351.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PJ.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050166,
     "wof:geomhash":"13a9ed8987f384573b825bcf52f1484b",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108562351,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Paryan",
     "wof:parent_id":1108803081,
     "wof:placetype":"county",

--- a/data/110/856/235/3/1108562353.geojson
+++ b/data/110/856/235/3/1108562353.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GR.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050167,
     "wof:geomhash":"04bbd546ab8c4ea1cbc8c4cc3c4e66eb",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562353,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Pasaband",
     "wof:parent_id":85667519,
     "wof:placetype":"county",

--- a/data/110/856/235/7/1108562357.geojson
+++ b/data/110/856/235/7/1108562357.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.FB.PK",
         "wd:id":"Q3696097"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050168,
     "wof:geomhash":"bdc57ac5338c6b8989d2b02f6d9ac77d",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108562357,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Pashtun Kot",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/235/9/1108562359.geojson
+++ b/data/110/856/235/9/1108562359.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HR.PZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050169,
     "wof:geomhash":"9bbe1ddbd4febc9a61a48936feec2556",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562359,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Pashtun Zarghun",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/110/856/236/1/1108562361.geojson
+++ b/data/110/856/236/1/1108562361.geojson
@@ -128,6 +128,7 @@
     "wof:concordances":{
         "hasc:id":"AF.LW.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050170,
     "wof:geomhash":"e386d019129dd695ccd7a95838bb6326",
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108562361,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886619,
     "wof:name":"Puli Alam",
     "wof:parent_id":85667623,
     "wof:placetype":"county",

--- a/data/110/856/236/3/1108562363.geojson
+++ b/data/110/856/236/3/1108562363.geojson
@@ -133,6 +133,7 @@
         "hasc:id":"AF.BL.PH",
         "wd:id":"Q2376379"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050171,
     "wof:geomhash":"b002f1062524eadceeea4454549d380d",
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108562363,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886619,
     "wof:name":"Puli Hisar",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/236/5/1108562365.geojson
+++ b/data/110/856/236/5/1108562365.geojson
@@ -179,6 +179,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BL.PK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050172,
     "wof:geomhash":"f9b1a3eda507c8a66bc2bea65f8f5c73",
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":1108562365,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886619,
     "wof:name":"Puli Khumri",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/236/7/1108562367.geojson
+++ b/data/110/856/236/7/1108562367.geojson
@@ -108,6 +108,7 @@
         "hasc:id":"AF.FH.PC",
         "wd:id":"Q2537771"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050178,
     "wof:geomhash":"b16818f9a12c589593d5d23a23c64911",
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108562367,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886619,
     "wof:name":"Pur Chaman",
     "wof:parent_id":85667527,
     "wof:placetype":"county",

--- a/data/110/856/236/9/1108562369.geojson
+++ b/data/110/856/236/9/1108562369.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.FH.PR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050179,
     "wof:geomhash":"859d0a3846fbf7dd2c8ac4e96a4ef6e1",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562369,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Pusht Rod",
     "wof:parent_id":85667527,
     "wof:placetype":"county",

--- a/data/110/856/237/1/1108562371.geojson
+++ b/data/110/856/237/1/1108562371.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"AF.BG.QD",
         "wd:id":"Q2429297"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050181,
     "wof:geomhash":"9d0900a8cc768a7beae7d489977612d6",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108562371,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886710,
     "wof:name":"Qadis",
     "wof:parent_id":85667493,
     "wof:placetype":"county",

--- a/data/110/856/237/5/1108562375.geojson
+++ b/data/110/856/237/5/1108562375.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.FH.QK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050182,
     "wof:geomhash":"c505b1287355415683dcc781111e14d9",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562375,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Qala Ka",
     "wof:parent_id":85667527,
     "wof:placetype":"county",

--- a/data/110/856/237/7/1108562377.geojson
+++ b/data/110/856/237/7/1108562377.geojson
@@ -115,6 +115,7 @@
         "hasc:id":"AF.BG.QN",
         "wd:id":"Q2711927"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050183,
     "wof:geomhash":"6f552d584e85f474ccb1a45181cf00c5",
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108562377,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886619,
     "wof:name":"Qala-I- Naw",
     "wof:parent_id":85667493,
     "wof:placetype":"county",

--- a/data/110/856/237/9/1108562379.geojson
+++ b/data/110/856/237/9/1108562379.geojson
@@ -79,6 +79,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KT.QA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050184,
     "wof:geomhash":"5b10823e4078a63cec951c27a20a1310",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108562379,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Qalandar",
     "wof:parent_id":85667563,
     "wof:placetype":"county",

--- a/data/110/856/238/1/1108562381.geojson
+++ b/data/110/856/238/1/1108562381.geojson
@@ -100,6 +100,7 @@
     "wof:concordances":{
         "hasc:id":"AF.ZB.QA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050185,
     "wof:geomhash":"fa8e5800bf5b50733e50cf7dfc223844",
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108562381,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886729,
     "wof:name":"Qalat",
     "wof:parent_id":85667555,
     "wof:placetype":"county",

--- a/data/110/856/238/3/1108562383.geojson
+++ b/data/110/856/238/3/1108562383.geojson
@@ -112,6 +112,7 @@
         "hasc:id":"AF.KZ.QZ",
         "wd:id":"Q2875955"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050186,
     "wof:geomhash":"9b1b1ccbfb7a6d809b7923d17f08ec3f",
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108562383,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Qalay-I- Zal",
     "wof:parent_id":85667585,
     "wof:placetype":"county",

--- a/data/110/856/238/5/1108562385.geojson
+++ b/data/110/856/238/5/1108562385.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.GZ.QA",
         "wd:id":"Q3500196"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050187,
     "wof:geomhash":"2692e415bd68fe18f8b1a4e2fe1c4c39",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108562385,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Qarabagh",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/238/7/1108562387.geojson
+++ b/data/110/856/238/7/1108562387.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KB.QB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050188,
     "wof:geomhash":"62c1b2c244972435db89d81f8ccfce5b",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562387,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Qarabagh",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/110/856/238/9/1108562389.geojson
+++ b/data/110/856/238/9/1108562389.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.FB.QQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050189,
     "wof:geomhash":"db45978d9d9758a701dc4273e9b145c5",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562389,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Qaramqol",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/239/3/1108562393.geojson
+++ b/data/110/856/239/3/1108562393.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"AF.LA.QA",
         "wd:id":"Q1230045"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050190,
     "wof:geomhash":"1927b590b5b35cf4b01ed98bbf5e565b",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108562393,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Qarghayi",
     "wof:parent_id":85667617,
     "wof:placetype":"county",

--- a/data/110/856/239/5/1108562395.geojson
+++ b/data/110/856/239/5/1108562395.geojson
@@ -82,6 +82,7 @@
     "wof:concordances":{
         "hasc:id":"AF.JW.QA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050192,
     "wof:geomhash":"b2d3678ba8b36c8d2709a2bba1dfce79",
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108562395,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Qarqin",
     "wof:parent_id":85667513,
     "wof:placetype":"county",

--- a/data/110/856/239/7/1108562397.geojson
+++ b/data/110/856/239/7/1108562397.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"AF.FB.QA",
         "wd:id":"Q3694278"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050193,
     "wof:geomhash":"88abc2b73a6c55bcdae6eda4238a96c5",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108562397,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Qaysar",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/239/9/1108562399.geojson
+++ b/data/110/856/239/9/1108562399.geojson
@@ -102,6 +102,7 @@
         "hasc:id":"AF.FB.QU",
         "wd:id":"Q13217328"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050194,
     "wof:geomhash":"bc5d5e65f351ef18af07755c4090a1a2",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108562399,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886619,
     "wof:name":"Qurghan",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/240/1/1108562401.geojson
+++ b/data/110/856/240/1/1108562401.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.JW.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050195,
     "wof:geomhash":"e893e948a22307bce2a6a038cce81996",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562401,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Qush Tepa",
     "wof:parent_id":85667513,
     "wof:placetype":"county",

--- a/data/110/856/240/3/1108562403.geojson
+++ b/data/110/856/240/3/1108562403.geojson
@@ -123,6 +123,7 @@
         "hasc:id":"AF.BD.RA",
         "wd:id":"Q2670909"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050196,
     "wof:geomhash":"03eba17f2fce4cf3f0c320a2f332c7d1",
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108562403,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886617,
     "wof:name":"Raghistan",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/240/5/1108562405.geojson
+++ b/data/110/856/240/5/1108562405.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GZ.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050197,
     "wof:geomhash":"6c63ed4f40752d26d091f23482c64141",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562405,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Rashidan",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/240/7/1108562407.geojson
+++ b/data/110/856/240/7/1108562407.geojson
@@ -105,6 +105,7 @@
         "hasc:id":"AF.HM.RE",
         "wd:id":"Q3506581"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050198,
     "wof:geomhash":"49b44efa934b3583dff98081c493b251",
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108562407,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886617,
     "wof:name":"Reg(Khanshin)",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/110/856/241/1/1108562411.geojson
+++ b/data/110/856/241/1/1108562411.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"AF.KD.RE",
         "wd:id":"Q3506581"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050199,
     "wof:geomhash":"bc55cbf8e8b9e2d5dafbf25ecd8522b3",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108562411,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886617,
     "wof:name":"Registan",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/241/3/1108562413.geojson
+++ b/data/110/856/241/3/1108562413.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.RO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050200,
     "wof:geomhash":"12ddbc810bad446ebcfb83822f50d282",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562413,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Rodat",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/241/5/1108562415.geojson
+++ b/data/110/856/241/5/1108562415.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PJ.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050201,
     "wof:geomhash":"fe15a07ee200f8f506952f7ea2cf37fd",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108562415,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Rukha",
     "wof:parent_id":1108803081,
     "wof:placetype":"county",

--- a/data/110/856/241/7/1108562417.geojson
+++ b/data/110/856/241/7/1108562417.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"AF.TK.RU",
         "wd:id":"Q2121351"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050202,
     "wof:geomhash":"fb05da96bc77a46382c86cc7d260543e",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108562417,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Rustaq",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/241/9/1108562419.geojson
+++ b/data/110/856/241/9/1108562419.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.SM.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050203,
     "wof:geomhash":"bf6aad4c79864fee4ee27dd1d89febd7",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562419,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Ruyi Du Ab",
     "wof:parent_id":85667631,
     "wof:placetype":"county",

--- a/data/110/856/242/1/1108562421.geojson
+++ b/data/110/856/242/1/1108562421.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KT.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050204,
     "wof:geomhash":"feaac5a1067b5e20587ed71f7970e79c",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108562421,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886615,
     "wof:name":"Sabri",
     "wof:parent_id":85667563,
     "wof:placetype":"county",

--- a/data/110/856/242/3/1108562423.geojson
+++ b/data/110/856/242/3/1108562423.geojson
@@ -76,6 +76,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GR.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050205,
     "wof:geomhash":"820a4ca35a524b85ab3dba68de04d8ef",
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108562423,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Saghar",
     "wof:parent_id":85667519,
     "wof:placetype":"county",

--- a/data/110/856/242/5/1108562425.geojson
+++ b/data/110/856/242/5/1108562425.geojson
@@ -79,6 +79,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PV.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050206,
     "wof:geomhash":"9c49ebec7cb81241a19c81070d6481ca",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108562425,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Salang",
     "wof:parent_id":85667627,
     "wof:placetype":"county",

--- a/data/110/856/242/9/1108562429.geojson
+++ b/data/110/856/242/9/1108562429.geojson
@@ -122,6 +122,7 @@
         "hasc:id":"AF.SP.SA",
         "wd:id":"Q3695802"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050207,
     "wof:geomhash":"f4a91af21aa2cd53c8f666310a84440f",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108562429,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886615,
     "wof:name":"Sangcharak",
     "wof:parent_id":85667523,
     "wof:placetype":"county",

--- a/data/110/856/243/1/1108562431.geojson
+++ b/data/110/856/243/1/1108562431.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"AF.DK.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050208,
     "wof:geomhash":"1a9ba045ed6c572f607216345efd1a7c",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108562431,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Sangi Takht",
     "wof:parent_id":1108803083,
     "wof:placetype":"county",

--- a/data/110/856/243/3/1108562433.geojson
+++ b/data/110/856/243/3/1108562433.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050210,
     "wof:geomhash":"2a6d160204cbdb5a34348a67e24a65ab",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562433,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Sar Hawza",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/243/5/1108562435.geojson
+++ b/data/110/856/243/5/1108562435.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"AF.SP.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050211,
     "wof:geomhash":"f0f0a3e769e3b28fae7f5de651ddd879",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108562435,
-    "wof:lastmodified":1694498102,
+    "wof:lastmodified":1695886728,
     "wof:name":"Sari Pul",
     "wof:parent_id":85667523,
     "wof:placetype":"county",

--- a/data/110/856/243/7/1108562437.geojson
+++ b/data/110/856/243/7/1108562437.geojson
@@ -102,6 +102,7 @@
         "hasc:id":"AF.KR.SI",
         "wd:id":"Q2217922"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050212,
     "wof:geomhash":"c21c326217e250000ea445ebb15904b0",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108562437,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886714,
     "wof:name":"Sarkani",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/243/9/1108562439.geojson
+++ b/data/110/856/243/9/1108562439.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PV.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050214,
     "wof:geomhash":"d6035c50a9c898947a2a8d8dbeffdc4f",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562439,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Sayd Khel",
     "wof:parent_id":85667627,
     "wof:placetype":"county",

--- a/data/110/856/244/1/1108562441.geojson
+++ b/data/110/856/244/1/1108562441.geojson
@@ -111,6 +111,7 @@
         "hasc:id":"AF.VR.SA",
         "wd:id":"Q2213502"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050215,
     "wof:geomhash":"78d3be40c163610d669b5645242e67ad",
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108562441,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Saydabad",
     "wof:parent_id":85667635,
     "wof:placetype":"county",

--- a/data/110/856/244/3/1108562443.geojson
+++ b/data/110/856/244/3/1108562443.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PT.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050216,
     "wof:geomhash":"14eb83e2d94412bed41d5da21f9aa656",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562443,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Sayed Karam",
     "wof:parent_id":85667641,
     "wof:placetype":"county",

--- a/data/110/856/244/7/1108562447.geojson
+++ b/data/110/856/244/7/1108562447.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BM.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050217,
     "wof:geomhash":"de98e994009228ebdf5a0f2460381b25",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562447,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Sayghan",
     "wof:parent_id":85667503,
     "wof:placetype":"county",

--- a/data/110/856/244/9/1108562449.geojson
+++ b/data/110/856/244/9/1108562449.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.SP.SY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050218,
     "wof:geomhash":"a718891d7d589bd317399ddc44a42a38",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562449,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Sayyad",
     "wof:parent_id":85667523,
     "wof:placetype":"county",

--- a/data/110/856/245/1/1108562451.geojson
+++ b/data/110/856/245/1/1108562451.geojson
@@ -114,6 +114,7 @@
         "hasc:id":"AF.KD.SW",
         "wd:id":"Q2669304"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050219,
     "wof:geomhash":"a733436d824ba0fb684adbc981f69c6f",
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108562451,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886614,
     "wof:name":"Shah Wali Kot",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/245/3/1108562453.geojson
+++ b/data/110/856/245/3/1108562453.geojson
@@ -117,6 +117,7 @@
         "hasc:id":"AF.BD.SD",
         "wd:id":"Q3918397"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050220,
     "wof:geomhash":"b5f6ce42c9bc5a6d4302a8cf67338792",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108562453,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886615,
     "wof:name":"Shahada",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/245/5/1108562455.geojson
+++ b/data/110/856/245/5/1108562455.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.OZ.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050221,
     "wof:geomhash":"67e8a6e485bf27ee7972ef3fb3909917",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562455,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Shahidi Hassas",
     "wof:parent_id":85667541,
     "wof:placetype":"county",

--- a/data/110/856/245/7/1108562457.geojson
+++ b/data/110/856/245/7/1108562457.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.ZB.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050222,
     "wof:geomhash":"d70fed5062ef4d96dfb2f8ab89105a19",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562457,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Shahjoy",
     "wof:parent_id":85667555,
     "wof:placetype":"county",

--- a/data/110/856/245/9/1108562459.geojson
+++ b/data/110/856/245/9/1108562459.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"AF.BD.SB",
         "wd:id":"Q3696221"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050224,
     "wof:geomhash":"89956f86ba0076dea10275b1484f9b46",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108562459,
-    "wof:lastmodified":1694497828,
+    "wof:lastmodified":1695886615,
     "wof:name":"Shahri Buzurg",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/246/1/1108562461.geojson
+++ b/data/110/856/246/1/1108562461.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.DK.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050225,
     "wof:geomhash":"29aac812c44e3de40c90091013d766d1",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562461,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Shahristan",
     "wof:parent_id":1108803083,
     "wof:placetype":"county",

--- a/data/110/856/246/5/1108562465.geojson
+++ b/data/110/856/246/5/1108562465.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KB.SD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050226,
     "wof:geomhash":"ac81524d299ea9999751c60e52e36864",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562465,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Shakardara",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/110/856/246/7/1108562467.geojson
+++ b/data/110/856/246/7/1108562467.geojson
@@ -98,6 +98,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BD.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050227,
     "wof:geomhash":"3b83e0de8120bd5cbbc4816d0b6c94ad",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108562467,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886712,
     "wof:name":"Shaki",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/246/9/1108562469.geojson
+++ b/data/110/856/246/9/1108562469.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KT.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050228,
     "wof:geomhash":"181206906eb09bb4e5573d54db249b16",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562469,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886713,
     "wof:name":"Shamal",
     "wof:parent_id":85667563,
     "wof:placetype":"county",

--- a/data/110/856/247/1/1108562471.geojson
+++ b/data/110/856/247/1/1108562471.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.ZB.SZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050229,
     "wof:geomhash":"500be30668e7e9f11f084a37509efaa6",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562471,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886713,
     "wof:name":"Shamulzayi",
     "wof:parent_id":85667555,
     "wof:placetype":"county",

--- a/data/110/856/247/3/1108562473.geojson
+++ b/data/110/856/247/3/1108562473.geojson
@@ -56,6 +56,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BK.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050230,
     "wof:geomhash":"7619fb02d630c496c08c1d3f8af202ad",
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1108562473,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Sharak Hairatan",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/247/5/1108562475.geojson
+++ b/data/110/856/247/5/1108562475.geojson
@@ -79,6 +79,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050231,
     "wof:geomhash":"7299a3c02e8b65c75f112bf5fde65fee",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108562475,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886617,
     "wof:name":"Sharan",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/247/7/1108562477.geojson
+++ b/data/110/856/247/7/1108562477.geojson
@@ -102,6 +102,7 @@
         "hasc:id":"AF.PT.SW",
         "wd:id":"Q1864045"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050232,
     "wof:geomhash":"94bac6e399cbd9ac395d39587dfc9589",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108562477,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886713,
     "wof:name":"Shawak",
     "wof:parent_id":85667641,
     "wof:placetype":"county",

--- a/data/110/856/247/9/1108562479.geojson
+++ b/data/110/856/247/9/1108562479.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KR.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050233,
     "wof:geomhash":"ccbbdb99e9884c537b5094822f38363f",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562479,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886713,
     "wof:name":"Shaygal wa shital",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/248/3/1108562483.geojson
+++ b/data/110/856/248/3/1108562483.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PV.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050234,
     "wof:geomhash":"766760897378e4887891f9f4c1633e55",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562483,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886713,
     "wof:name":"Shekh Ali",
     "wof:parent_id":85667627,
     "wof:placetype":"county",

--- a/data/110/856/248/5/1108562485.geojson
+++ b/data/110/856/248/5/1108562485.geojson
@@ -111,6 +111,7 @@
         "hasc:id":"AF.FH.SK",
         "wd:id":"Q2537733"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050235,
     "wof:geomhash":"c2a315a9bbc06f24aabcbb64f0cabded",
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108562485,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886617,
     "wof:name":"Shib Koh",
     "wof:parent_id":85667527,
     "wof:placetype":"county",

--- a/data/110/856/248/7/1108562487.geojson
+++ b/data/110/856/248/7/1108562487.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.BM.SH",
         "wd:id":"Q2482517"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050236,
     "wof:geomhash":"b764b0f22af550a434e0beca7bdacc24",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108562487,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886713,
     "wof:name":"Shibar",
     "wof:parent_id":85667503,
     "wof:placetype":"county",

--- a/data/110/856/248/9/1108562489.geojson
+++ b/data/110/856/248/9/1108562489.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.JW.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050237,
     "wof:geomhash":"299f3181d4230a85487b9dc7e639935a",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562489,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886713,
     "wof:name":"Shibirghan",
     "wof:parent_id":85667513,
     "wof:placetype":"county",

--- a/data/110/856/249/1/1108562491.geojson
+++ b/data/110/856/249/1/1108562491.geojson
@@ -116,6 +116,7 @@
         "hasc:id":"AF.BD.SG",
         "wd:id":"Q3694396"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050238,
     "wof:geomhash":"b6262a5f8183e41b292bd617be2d9d7a",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108562491,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886618,
     "wof:name":"Shighnan",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/249/3/1108562493.geojson
+++ b/data/110/856/249/3/1108562493.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.ZB.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050240,
     "wof:geomhash":"e11d03f4b127136afb82d1c779ec92ba",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562493,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886713,
     "wof:name":"Shinkay",
     "wof:parent_id":85667555,
     "wof:placetype":"county",

--- a/data/110/856/249/5/1108562495.geojson
+++ b/data/110/856/249/5/1108562495.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PV.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050241,
     "wof:geomhash":"fd1dd1f7a44f7608767e1895729c9b89",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108562495,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886713,
     "wof:name":"Shinwari",
     "wof:parent_id":85667627,
     "wof:placetype":"county",

--- a/data/110/856/249/7/1108562497.geojson
+++ b/data/110/856/249/7/1108562497.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"AF.NG.SW",
         "wd:id":"Q2217632"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050243,
     "wof:geomhash":"945601a2125fa628da4c408f89bd6b54",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108562497,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886713,
     "wof:name":"Shinwar",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/250/1/1108562501.geojson
+++ b/data/110/856/250/1/1108562501.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"AF.FB.ST",
         "wd:id":"Q3694468"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050244,
     "wof:geomhash":"bf1bd8caed488823e07bcef3a35d5621",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108562501,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886713,
     "wof:name":"Shirin Tagab",
     "wof:parent_id":85667509,
     "wof:placetype":"county",

--- a/data/110/856/250/3/1108562503.geojson
+++ b/data/110/856/250/3/1108562503.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NG.SZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050245,
     "wof:geomhash":"a0e466fa9cf564b2fe9447a0256a0bfe",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108562503,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886714,
     "wof:name":"Shirzad",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/250/5/1108562505.geojson
+++ b/data/110/856/250/5/1108562505.geojson
@@ -116,6 +116,7 @@
         "hasc:id":"AF.BK.SL",
         "wd:id":"Q2673974"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050246,
     "wof:geomhash":"5890d771e68fdea4d7bfa7d138579703",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108562505,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886714,
     "wof:name":"Sholgara",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/250/7/1108562507.geojson
+++ b/data/110/856/250/7/1108562507.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KD.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050247,
     "wof:geomhash":"3c530748cf78b68d8563a10680c05499",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562507,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886714,
     "wof:name":"Shorabak",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/250/9/1108562509.geojson
+++ b/data/110/856/250/9/1108562509.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.BK.SR",
         "wd:id":"Q3696060"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050248,
     "wof:geomhash":"a5d239f8c42abdb5b0bca4c1fd9edb68",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108562509,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886714,
     "wof:name":"Shortepa",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/251/1/1108562511.geojson
+++ b/data/110/856/251/1/1108562511.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PJ.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050249,
     "wof:geomhash":"2a3c4d0b0b4b9ff4d4acf6604d74ba2c",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108562511,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886714,
     "wof:name":"Shutul",
     "wof:parent_id":1108803081,
     "wof:placetype":"county",

--- a/data/110/856/251/3/1108562513.geojson
+++ b/data/110/856/251/3/1108562513.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PV.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050250,
     "wof:geomhash":"e041b4d64f84154e6083c689319dafa5",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562513,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886714,
     "wof:name":"Sia Gird ( Ghorbund)",
     "wof:parent_id":85667627,
     "wof:placetype":"county",

--- a/data/110/856/251/5/1108562515.geojson
+++ b/data/110/856/251/5/1108562515.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.SP.SQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050251,
     "wof:geomhash":"5485274e544a8b3814f5171f322cde6c",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562515,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886714,
     "wof:name":"Sozma Qala",
     "wof:parent_id":85667523,
     "wof:placetype":"county",

--- a/data/110/856/251/9/1108562519.geojson
+++ b/data/110/856/251/9/1108562519.geojson
@@ -123,6 +123,7 @@
         "hasc:id":"AF.KD.SB",
         "wd:id":"Q2673896"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050252,
     "wof:geomhash":"eb5914004d50ba21b8e0128f102fd85d",
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108562519,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886615,
     "wof:name":"Spin Boldak",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/252/1/1108562521.geojson
+++ b/data/110/856/252/1/1108562521.geojson
@@ -82,6 +82,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KT.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050253,
     "wof:geomhash":"6296c3dda0d8010c688b06b40f6819cb",
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108562521,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886620,
     "wof:name":"Spira",
     "wof:parent_id":85667563,
     "wof:placetype":"county",

--- a/data/110/856/252/3/1108562523.geojson
+++ b/data/110/856/252/3/1108562523.geojson
@@ -114,6 +114,7 @@
         "hasc:id":"AF.NG.SR",
         "wd:id":"Q3695826"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050254,
     "wof:geomhash":"7be339a4164de101153bec9243d73015",
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108562523,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886714,
     "wof:name":"Surkh Rod",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/110/856/252/5/1108562525.geojson
+++ b/data/110/856/252/5/1108562525.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"AF.PV.SP",
         "wd:id":"Q1649427"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050255,
     "wof:geomhash":"6750e1b1b5d750c590fcdbaa732a04e6",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108562525,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886714,
     "wof:name":"Surkhi Parsa",
     "wof:parent_id":85667627,
     "wof:placetype":"county",

--- a/data/110/856/252/7/1108562527.geojson
+++ b/data/110/856/252/7/1108562527.geojson
@@ -131,6 +131,7 @@
         "hasc:id":"AF.KB.SU",
         "wd:id":"Q2002430"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050256,
     "wof:geomhash":"342cd208313fa89ba2d8e94a78190365",
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108562527,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886620,
     "wof:name":"Surobi",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/110/856/252/9/1108562529.geojson
+++ b/data/110/856/252/9/1108562529.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BD.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050257,
     "wof:geomhash":"147599536ba10613dcab57a2f79197da",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562529,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886714,
     "wof:name":"Tagab (Kishmi Bala)",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/253/1/1108562531.geojson
+++ b/data/110/856/253/1/1108562531.geojson
@@ -79,6 +79,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KP.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050258,
     "wof:geomhash":"6791f62fa7e2b518d8d3f11a569aea4d",
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108562531,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886714,
     "wof:name":"Tagab",
     "wof:parent_id":85667609,
     "wof:placetype":"county",

--- a/data/110/856/253/3/1108562533.geojson
+++ b/data/110/856/253/3/1108562533.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BL.TB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050259,
     "wof:geomhash":"ff9ab715c917a3484f6f17949282ca29",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562533,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886715,
     "wof:name":"Tala Wa Barfak",
     "wof:parent_id":85667601,
     "wof:placetype":"county",

--- a/data/110/856/253/7/1108562537.geojson
+++ b/data/110/856/253/7/1108562537.geojson
@@ -85,6 +85,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KT.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050260,
     "wof:geomhash":"86d469b23f32afcbcf92a5df3adeccad",
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108562537,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886619,
     "wof:name":"Tani",
     "wof:parent_id":85667563,
     "wof:placetype":"county",

--- a/data/110/856/253/9/1108562539.geojson
+++ b/data/110/856/253/9/1108562539.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.ZB.TJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050261,
     "wof:geomhash":"097300c5443b8359dba2c2f28d4896ff",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562539,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886715,
     "wof:name":"Tarnak Wa Jaldak",
     "wof:parent_id":85667555,
     "wof:placetype":"county",

--- a/data/110/856/254/1/1108562541.geojson
+++ b/data/110/856/254/1/1108562541.geojson
@@ -126,6 +126,7 @@
         "hasc:id":"AF.BD.TI",
         "wd:id":"Q2879146"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050263,
     "wof:geomhash":"d88ef5236daaeff851c2da0147a2edbc",
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108562541,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886619,
     "wof:name":"Tashkan",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/254/3/1108562543.geojson
+++ b/data/110/856/254/3/1108562543.geojson
@@ -105,6 +105,7 @@
         "hasc:id":"AF.GR.TA",
         "wd:id":"Q2609226"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050264,
     "wof:geomhash":"91a19aeb1d2efa18acf5b33a3fdc18ad",
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108562543,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886715,
     "wof:name":"Taywara",
     "wof:parent_id":85667519,
     "wof:placetype":"county",

--- a/data/110/856/254/5/1108562545.geojson
+++ b/data/110/856/254/5/1108562545.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KT.TZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050265,
     "wof:geomhash":"fb7dad240d9669b11e0f212ba573fbe3",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562545,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886715,
     "wof:name":"Tere Zayi",
     "wof:parent_id":85667563,
     "wof:placetype":"county",

--- a/data/110/856/254/7/1108562547.geojson
+++ b/data/110/856/254/7/1108562547.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.OZ.TK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050266,
     "wof:geomhash":"dc4fe6d7f3380798d6b63cd5f38a06a7",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562547,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886715,
     "wof:name":"Tirin Kot",
     "wof:parent_id":85667541,
     "wof:placetype":"county",

--- a/data/110/856/254/9/1108562549.geojson
+++ b/data/110/856/254/9/1108562549.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GR.TU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050267,
     "wof:geomhash":"40802173c9e77197f013549dc5ae0b3e",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562549,
-    "wof:lastmodified":1694497830,
+    "wof:lastmodified":1695886619,
     "wof:name":"Tulak",
     "wof:parent_id":85667519,
     "wof:placetype":"county",

--- a/data/110/856/255/1/1108562551.geojson
+++ b/data/110/856/255/1/1108562551.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.TU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050268,
     "wof:geomhash":"a247c41f66ff0afee9331d979f47c430",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562551,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886715,
     "wof:name":"Turwo",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/255/5/1108562555.geojson
+++ b/data/110/856/255/5/1108562555.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PJ.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050269,
     "wof:geomhash":"deab45322bac49af3146c4af70f77221",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562555,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886715,
     "wof:name":"Unaba",
     "wof:parent_id":1108803081,
     "wof:placetype":"county",

--- a/data/110/856/255/7/1108562557.geojson
+++ b/data/110/856/255/7/1108562557.geojson
@@ -73,6 +73,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.UR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050270,
     "wof:geomhash":"8fefb4e3f7197f23e42f22a07edc7428",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108562557,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886715,
     "wof:name":"Urgun",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/255/9/1108562559.geojson
+++ b/data/110/856/255/9/1108562559.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GZ.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050271,
     "wof:geomhash":"98aec35fb87e8e36b1eae2e6ca74e08f",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562559,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886715,
     "wof:name":"Waghaz",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/256/1/1108562561.geojson
+++ b/data/110/856/256/1/1108562561.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GZ.WM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050273,
     "wof:geomhash":"e650e34e3847a97871aff7202ceefeca",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562561,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886715,
     "wof:name":"Wali Muhammadi Shahid",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/256/3/1108562563.geojson
+++ b/data/110/856/256/3/1108562563.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"AF.NR.WM",
         "wd:id":"Q2217555"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050274,
     "wof:geomhash":"013530a64fbe764e22ba446cf7222d72",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108562563,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886715,
     "wof:name":"Wama",
     "wof:parent_id":85667577,
     "wof:placetype":"county",

--- a/data/110/856/256/5/1108562565.geojson
+++ b/data/110/856/256/5/1108562565.geojson
@@ -120,6 +120,7 @@
         "hasc:id":"AF.BM.WA",
         "wd:id":"Q2482504"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050275,
     "wof:geomhash":"06e70e2db58c0ce973f642879c0b9a4f",
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108562565,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886715,
     "wof:name":"Waras",
     "wof:parent_id":85667503,
     "wof:placetype":"county",

--- a/data/110/856/256/7/1108562567.geojson
+++ b/data/110/856/256/7/1108562567.geojson
@@ -117,6 +117,7 @@
         "hasc:id":"AF.BD.WJ",
         "wd:id":"Q3918397"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050276,
     "wof:geomhash":"dccf15bccfb21d873ea58b29b08f0b79",
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108562567,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886615,
     "wof:name":"Warduj",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/256/9/1108562569.geojson
+++ b/data/110/856/256/9/1108562569.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.TK.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050277,
     "wof:geomhash":"43179a616706421ba85669e1d3b01c0e",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562569,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886715,
     "wof:name":"Warsaj",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/257/3/1108562573.geojson
+++ b/data/110/856/257/3/1108562573.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"AF.HM.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050278,
     "wof:geomhash":"5df755f2edd623533418cb57dcfd1452",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108562573,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886716,
     "wof:name":"Washer",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/110/856/257/5/1108562575.geojson
+++ b/data/110/856/257/5/1108562575.geojson
@@ -115,6 +115,7 @@
         "hasc:id":"AF.KR.WP",
         "wd:id":"Q798477"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050279,
     "wof:geomhash":"02d04b46b7195eb028e74823b982b026",
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108562575,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886716,
     "wof:name":"Wata Pur",
     "wof:parent_id":85667581,
     "wof:placetype":"county",

--- a/data/110/856/257/7/1108562577.geojson
+++ b/data/110/856/257/7/1108562577.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"AF.NR.WG",
         "wd:id":"Q2213873"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050280,
     "wof:geomhash":"a06c74f0a9615c9dc1dcb4a3b785f742",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108562577,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886716,
     "wof:name":"Waygal",
     "wof:parent_id":85667577,
     "wof:placetype":"county",

--- a/data/110/856/257/9/1108562579.geojson
+++ b/data/110/856/257/9/1108562579.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050281,
     "wof:geomhash":"94fc9495c1d44566fcb61df05a592687",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562579,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886716,
     "wof:name":"Waza Khwa",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/258/1/1108562581.geojson
+++ b/data/110/856/258/1/1108562581.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.WO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050282,
     "wof:geomhash":"f73bc49b924a085af65ffdc311d5b12b",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562581,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886716,
     "wof:name":"Wor Mayi",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/258/3/1108562583.geojson
+++ b/data/110/856/258/3/1108562583.geojson
@@ -120,6 +120,7 @@
         "hasc:id":"AF.BD.YS",
         "wd:id":"Q2673892"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050283,
     "wof:geomhash":"ff2ed6f336efa2a9f979d16ac8c9b68d",
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108562583,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886615,
     "wof:name":"Yaftal Sufla",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/258/5/1108562585.geojson
+++ b/data/110/856/258/5/1108562585.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.YY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050284,
     "wof:geomhash":"335f67122778dc1e76f6e11ac927c5d0",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562585,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886716,
     "wof:name":"Yahya Khel",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/258/7/1108562587.geojson
+++ b/data/110/856/258/7/1108562587.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"AF.BM.YA",
         "wd:id":"Q2482509"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050285,
     "wof:geomhash":"3cd9a00e239407abccc6e5c1eda80af9",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108562587,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886716,
     "wof:name":"Yakawlang",
     "wof:parent_id":85667503,
     "wof:placetype":"county",

--- a/data/110/856/259/1/1108562591.geojson
+++ b/data/110/856/259/1/1108562591.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BD.YG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050286,
     "wof:geomhash":"1ceb36dea4772671740644131b7695d7",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562591,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886716,
     "wof:name":"Yamgan (Girwan)",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/259/3/1108562593.geojson
+++ b/data/110/856/259/3/1108562593.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"AF.TK.YQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050287,
     "wof:geomhash":"dac9934e3f04a83a76f3955ac4e637ac",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108562593,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886717,
     "wof:name":"Yangi Qala",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/110/856/259/5/1108562595.geojson
+++ b/data/110/856/259/5/1108562595.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BD.YW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050288,
     "wof:geomhash":"2d389ba833371b61462e75045af8fe6f",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108562595,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886717,
     "wof:name":"Yawan",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/259/7/1108562597.geojson
+++ b/data/110/856/259/7/1108562597.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.YK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050289,
     "wof:geomhash":"bd7e3b8dad0462cc3e4558c9718ad95b",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562597,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886717,
     "wof:name":"Yosuf Khel",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/259/9/1108562599.geojson
+++ b/data/110/856/259/9/1108562599.geojson
@@ -105,6 +105,7 @@
         "hasc:id":"AF.PT.JD",
         "wd:id":"Q140102"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050290,
     "wof:geomhash":"94070c804acbd00a4ef0b6296bb14318",
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108562599,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886717,
     "wof:name":"Zadran",
     "wof:parent_id":85667641,
     "wof:placetype":"county",

--- a/data/110/856/260/1/1108562601.geojson
+++ b/data/110/856/260/1/1108562601.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.GZ.ZK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050291,
     "wof:geomhash":"61173023a19c784b968520a2c1f186e4",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562601,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886717,
     "wof:name":"Zana Khan",
     "wof:parent_id":85667561,
     "wof:placetype":"county",

--- a/data/110/856/260/3/1108562603.geojson
+++ b/data/110/856/260/3/1108562603.geojson
@@ -163,6 +163,7 @@
     "wof:concordances":{
         "hasc:id":"AF.NM.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050293,
     "wof:geomhash":"d6f75fe46846ce5f7564097865c36e8a",
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":1108562603,
-    "wof:lastmodified":1694498102,
+    "wof:lastmodified":1695886728,
     "wof:name":"Zaranj",
     "wof:parent_id":85667537,
     "wof:placetype":"county",

--- a/data/110/856/260/5/1108562605.geojson
+++ b/data/110/856/260/5/1108562605.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.ZS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050294,
     "wof:geomhash":"f4209104509691649bb9c6afa4d42789",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562605,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886717,
     "wof:name":"Zarghun Shahr",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/260/9/1108562609.geojson
+++ b/data/110/856/260/9/1108562609.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"AF.BK.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050295,
     "wof:geomhash":"76eda1d61a2d18c066349ef6eee6a665",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108562609,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886717,
     "wof:name":"Zari",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/110/856/261/1/1108562611.geojson
+++ b/data/110/856/261/1/1108562611.geojson
@@ -125,6 +125,7 @@
         "hasc:id":"AF.BD.ZE",
         "wd:id":"Q198331"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050296,
     "wof:geomhash":"1d538ac2681f76533447da4af8a44157",
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108562611,
-    "wof:lastmodified":1694497829,
+    "wof:lastmodified":1695886615,
     "wof:name":"Zebak",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/110/856/261/3/1108562613.geojson
+++ b/data/110/856/261/3/1108562613.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"AF.KD.ZH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050297,
     "wof:geomhash":"15b4aaa5392b09e1daea73e5d47204ee",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562613,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886717,
     "wof:name":"Zhari",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/110/856/261/5/1108562615.geojson
+++ b/data/110/856/261/5/1108562615.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"AF.PK.ZI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050304,
     "wof:geomhash":"a45fe8080d31fe657932b747cf3f82a3",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108562615,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886717,
     "wof:name":"Ziruk",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/110/856/261/7/1108562617.geojson
+++ b/data/110/856/261/7/1108562617.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"AF.PT.ZU",
         "wd:id":"Q2277263"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1474050305,
     "wof:geomhash":"b4494534e97baf628b1b97906d2c1d38",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108562617,
-    "wof:lastmodified":1694497961,
+    "wof:lastmodified":1695886717,
     "wof:name":"Zurmat",
     "wof:parent_id":85667641,
     "wof:placetype":"county",

--- a/data/110/880/308/1/1108803081.geojson
+++ b/data/110/880/308/1/1108803081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.370997,
-    "geom:area_square_m":3737139549.684708,
+    "geom:area_square_m":3737139722.241412,
     "geom:bbox":"69.235599,35.0778,70.301437,35.904266",
     "geom:latitude":35.447451,
     "geom:longitude":69.795889,
@@ -275,12 +275,14 @@
     "wof:concordances":{
         "fips:code":"AF42",
         "hasc:id":"AF.PJ",
+        "iso:code":"AF-PAN",
         "iso:id":"AF-PAN",
         "wd:id":"Q181235"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:created":1485205485,
-    "wof:geomhash":"bdcfa275552127838727df81b39f302c",
+    "wof:geomhash":"b4b42d934b89504e4e284abee202c7b0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -300,7 +302,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849253,
+    "wof:lastmodified":1695884478,
     "wof:name":"Panjshir",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/110/880/308/3/1108803083.geojson
+++ b/data/110/880/308/3/1108803083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.626512,
-    "geom:area_square_m":16733284237.27552,
+    "geom:area_square_m":16733283622.6159,
     "geom:bbox":"65.230686,32.924813,67.418489,34.370034",
     "geom:latitude":33.693973,
     "geom:longitude":66.172191,
@@ -272,12 +272,14 @@
     "wof:concordances":{
         "fips:code":"AF41",
         "hasc:id":"AF.DK",
+        "iso:code":"AF-DAY",
         "iso:id":"AF-DAY",
         "wd:id":"Q181220"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:created":1485205489,
-    "wof:geomhash":"ab509a8da6ab413d1c65111f1013e155",
+    "wof:geomhash":"92f514666490d8d834e7d4dedf1df8db",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -297,7 +299,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849254,
+    "wof:lastmodified":1695884479,
     "wof:name":"Daikondi",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/421/166/641/421166641.geojson
+++ b/data/421/166/641/421166641.geojson
@@ -139,6 +139,7 @@
         "wd:id":"Q3695179",
         "wk:page":"Gardez District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459008697,
     "wof:geom_alt":[
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":421166641,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886729,
     "wof:name":"Gardiz",
     "wof:parent_id":85667641,
     "wof:placetype":"county",

--- a/data/421/171/021/421171021.geojson
+++ b/data/421/171/021/421171021.geojson
@@ -113,6 +113,7 @@
         "wd:id":"Q3473688",
         "wk:page":"Surobi, Kabul"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459008879,
     "wof:geom_alt":[
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421171021,
-    "wof:lastmodified":1694497895,
+    "wof:lastmodified":1695886712,
     "wof:name":"Sarobi",
     "wof:parent_id":85667567,
     "wof:placetype":"county",

--- a/data/421/171/023/421171023.geojson
+++ b/data/421/171/023/421171023.geojson
@@ -103,6 +103,7 @@
         "hasc:id":"AF.KB.GD",
         "qs_pg:id":1205789
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459008879,
     "wof:geom_alt":[
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":421171023,
-    "wof:lastmodified":1694497953,
+    "wof:lastmodified":1695886701,
     "wof:name":"Guldara",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/421/171/025/421171025.geojson
+++ b/data/421/171/025/421171025.geojson
@@ -143,6 +143,7 @@
         "wd:id":"Q3696078",
         "wk:page":"Paghman District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459008879,
     "wof:geom_alt":[
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":421171025,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886695,
     "wof:name":"Baghran",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/421/171/977/421171977.geojson
+++ b/data/421/171/977/421171977.geojson
@@ -167,6 +167,7 @@
         "qs_pg:id":1288759,
         "wd:id":"Q6344428"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421168799
     ],
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":421171977,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886729,
     "wof:name":"Kabul",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/421/177/081/421177081.geojson
+++ b/data/421/177/081/421177081.geojson
@@ -130,6 +130,7 @@
         "wd:id":"Q6597025",
         "wk:page":"Sharana District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009132,
     "wof:geom_alt":[
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421177081,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886712,
     "wof:name":"Shahrak",
     "wof:parent_id":85667519,
     "wof:placetype":"county",

--- a/data/421/182/251/421182251.geojson
+++ b/data/421/182/251/421182251.geojson
@@ -151,6 +151,7 @@
         "wd:id":"Q2572224",
         "wk:page":"Bamyan District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009323,
     "wof:geom_alt":[
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":421182251,
-    "wof:lastmodified":1694497950,
+    "wof:lastmodified":1695886696,
     "wof:name":"Bamyan",
     "wof:parent_id":85667503,
     "wof:placetype":"county",

--- a/data/421/182/253/421182253.geojson
+++ b/data/421/182/253/421182253.geojson
@@ -104,6 +104,7 @@
         "wd:id":"Q4842103",
         "wk:page":"Bagrami"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009323,
     "wof:geom_alt":[
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":421182253,
-    "wof:lastmodified":1694497949,
+    "wof:lastmodified":1695886695,
     "wof:name":"Bagrami",
     "wof:parent_id":85667603,
     "wof:placetype":"county",

--- a/data/421/182/991/421182991.geojson
+++ b/data/421/182/991/421182991.geojson
@@ -238,6 +238,7 @@
         "qs_pg:id":777052,
         "wd:id":"Q989293"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009354,
     "wof:geom_alt":[
@@ -253,7 +254,7 @@
         }
     ],
     "wof:id":421182991,
-    "wof:lastmodified":1694497895,
+    "wof:lastmodified":1695886712,
     "wof:name":"Kot",
     "wof:parent_id":85667591,
     "wof:placetype":"county",

--- a/data/421/183/887/421183887.geojson
+++ b/data/421/183/887/421183887.geojson
@@ -155,6 +155,7 @@
         "wd:id":"Q2670884",
         "wk:page":"Ishkashim District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009390,
     "wof:geom_alt":[
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":421183887,
-    "wof:lastmodified":1694497895,
+    "wof:lastmodified":1695886712,
     "wof:name":"Ishkashiem",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/421/187/941/421187941.geojson
+++ b/data/421/187/941/421187941.geojson
@@ -154,6 +154,7 @@
         "wd:id":"Q2509959",
         "wk:page":"Wakhan District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009528,
     "wof:geom_alt":[
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":421187941,
-    "wof:lastmodified":1694497895,
+    "wof:lastmodified":1695886712,
     "wof:name":"Wakhan",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/421/187/943/421187943.geojson
+++ b/data/421/187/943/421187943.geojson
@@ -127,6 +127,7 @@
         "wd:id":"Q799961",
         "wk:page":"Bagram District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009528,
     "wof:geom_alt":[
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421187943,
-    "wof:lastmodified":1694497950,
+    "wof:lastmodified":1695886696,
     "wof:name":"Bagram",
     "wof:parent_id":85667627,
     "wof:placetype":"county",

--- a/data/421/187/945/421187945.geojson
+++ b/data/421/187/945/421187945.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"AF.BK.NS",
         "qs_pg:id":1086826
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009529,
     "wof:geom_alt":[
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":421187945,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886708,
     "wof:name":"Nahri Shahi",
     "wof:parent_id":85667505,
     "wof:placetype":"county",

--- a/data/421/188/181/421188181.geojson
+++ b/data/421/188/181/421188181.geojson
@@ -328,6 +328,7 @@
         "qs_pg:id":12571,
         "wd:id":"Q108155"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009537,
     "wof:geom_alt":[
@@ -343,7 +344,7 @@
         }
     ],
     "wof:id":421188181,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886729,
     "wof:name":"Kunduz",
     "wof:parent_id":85667585,
     "wof:placetype":"county",

--- a/data/421/188/911/421188911.geojson
+++ b/data/421/188/911/421188911.geojson
@@ -133,6 +133,7 @@
         "wd:id":"Q3918440",
         "wk:page":"Taluqan District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009588,
     "wof:geom_alt":[
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421188911,
-    "wof:lastmodified":1694497895,
+    "wof:lastmodified":1695886712,
     "wof:name":"Taluqan",
     "wof:parent_id":85667595,
     "wof:placetype":"county",

--- a/data/421/191/409/421191409.geojson
+++ b/data/421/191/409/421191409.geojson
@@ -153,6 +153,7 @@
         "qs_pg:id":1136791,
         "wd:id":"Q2887829"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009691,
     "wof:geom_alt":[
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":421191409,
-    "wof:lastmodified":1694497895,
+    "wof:lastmodified":1695886713,
     "wof:name":"Fayzabad",
     "wof:parent_id":85667573,
     "wof:placetype":"county",

--- a/data/421/194/001/421194001.geojson
+++ b/data/421/194/001/421194001.geojson
@@ -91,6 +91,7 @@
         "hasc:id":"AF.PV.JA",
         "qs_pg:id":777037
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009790,
     "wof:geom_alt":[
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421194001,
-    "wof:lastmodified":1694497954,
+    "wof:lastmodified":1695886703,
     "wof:name":"Jabalussaraj",
     "wof:parent_id":85667627,
     "wof:placetype":"county",

--- a/data/421/194/569/421194569.geojson
+++ b/data/421/194/569/421194569.geojson
@@ -291,6 +291,7 @@
         "qs_pg:id":776983,
         "wd:id":"Q476800"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009812,
     "wof:geom_alt":[
@@ -306,7 +307,7 @@
         }
     ],
     "wof:id":421194569,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886729,
     "wof:name":"Lashkar Gah",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/421/194/803/421194803.geojson
+++ b/data/421/194/803/421194803.geojson
@@ -311,6 +311,7 @@
         "hasc:id":"AF.KD.KA",
         "qs_pg:id":186
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009820,
     "wof:geom_alt":[
@@ -326,7 +327,7 @@
         }
     ],
     "wof:id":421194803,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886729,
     "wof:name":"Kandahar",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/421/196/563/421196563.geojson
+++ b/data/421/196/563/421196563.geojson
@@ -91,6 +91,7 @@
         "hasc:id":"AF.KD.PA",
         "qs_pg:id":777038
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009885,
     "wof:geom_alt":[
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421196563,
-    "wof:lastmodified":1694497957,
+    "wof:lastmodified":1695886710,
     "wof:name":"Panjwayi",
     "wof:parent_id":85667549,
     "wof:placetype":"county",

--- a/data/421/197/035/421197035.geojson
+++ b/data/421/197/035/421197035.geojson
@@ -146,6 +146,7 @@
         "wd:id":"Q249296",
         "wk:page":"Batikal"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009900,
     "wof:geom_alt":[
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":421197035,
-    "wof:lastmodified":1694497958,
+    "wof:lastmodified":1695886711,
     "wof:name":"Sangin",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/421/198/905/421198905.geojson
+++ b/data/421/198/905/421198905.geojson
@@ -142,6 +142,7 @@
         "wd:id":"Q2714337",
         "wk:page":"Shindand District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009965,
     "wof:geom_alt":[
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":421198905,
-    "wof:lastmodified":1694497959,
+    "wof:lastmodified":1695886713,
     "wof:name":"Shindand",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/421/198/931/421198931.geojson
+++ b/data/421/198/931/421198931.geojson
@@ -120,6 +120,7 @@
         "wd:id":"Q5918492",
         "wk:page":"Zendeh Jan"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459009966,
     "wof:geom_alt":[
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421198931,
-    "wof:lastmodified":1694497960,
+    "wof:lastmodified":1695886716,
     "wof:name":"Zanda Jan",
     "wof:parent_id":85667497,
     "wof:placetype":"county",

--- a/data/421/202/037/421202037.geojson
+++ b/data/421/202/037/421202037.geojson
@@ -80,6 +80,7 @@
         "hasc:id":"AF.HM.NS",
         "qs_pg:id":118
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AF",
     "wof:created":1459010102,
     "wof:geom_alt":[
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":421202037,
-    "wof:lastmodified":1694497956,
+    "wof:lastmodified":1695886709,
     "wof:name":"Nahri Sarraj",
     "wof:parent_id":85667531,
     "wof:placetype":"county",

--- a/data/856/322/29/85632229.geojson
+++ b/data/856/322/29/85632229.geojson
@@ -1346,6 +1346,7 @@
         "hasc:id":"AF",
         "icao:code":"TA",
         "ioc:id":"AFG",
+        "iso:code":"AF",
         "itu:id":"AFG",
         "loc:id":"n79063030",
         "m49:code":"004",
@@ -1360,6 +1361,7 @@
         "wk:page":"Afghanistan",
         "wmo:id":"AF"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:country_alpha3":"AFG",
     "wof:geom_alt":[
@@ -1386,7 +1388,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1694639519,
+    "wof:lastmodified":1695881174,
     "wof:name":"Afghanistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/674/93/85667493.geojson
+++ b/data/856/674/93/85667493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.049032,
-    "geom:area_square_m":20718064791.436523,
+    "geom:area_square_m":20718064455.773697,
     "geom:bbox":"62.66658,34.511298,65.069072,36.036302",
     "geom:latitude":35.142281,
     "geom:longitude":63.736265,
@@ -374,6 +374,7 @@
         "gn:id":1147707,
         "gp:id":2344550,
         "hasc:id":"AF.BG",
+        "iso:code":"AF-BDG",
         "iso:id":"AF-BDG",
         "loc:id":"n85281890",
         "qs_pg:id":318247,
@@ -381,11 +382,12 @@
         "wd:id":"Q172052",
         "wk:page":"Badghis Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"13bd7fe274908df56b9a064913c7bc93",
+    "wof:geomhash":"8f678b538e62cd8e48a24f032968c9d0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -405,7 +407,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849241,
+    "wof:lastmodified":1695884849,
     "wof:name":"Badghis",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/674/97/85667497.geojson
+++ b/data/856/674/97/85667497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.308634,
-    "geom:area_square_m":54288452767.001732,
+    "geom:area_square_m":54288451793.216354,
     "geom:bbox":"60.475769,32.846797,64.482278,35.625266",
     "geom:latitude":34.200257,
     "geom:longitude":62.130624,
@@ -380,6 +380,7 @@
         "gn:id":1140025,
         "gp:id":2344558,
         "hasc:id":"AF.HR",
+        "iso:code":"AF-HER",
         "iso:id":"AF-HER",
         "loc:id":"n86066479",
         "qs_pg:id":235554,
@@ -387,11 +388,12 @@
         "wd:id":"Q182844",
         "wk:page":"Herat Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd1395a86797a81cd3a3ccbdce9260a9",
+    "wof:geomhash":"ce5492e509e02d0d9e3bd7b1fb01187e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -411,7 +413,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849242,
+    "wof:lastmodified":1695884478,
     "wof:name":"Herat",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/03/85667503.geojson
+++ b/data/856/675/03/85667503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.760632,
-    "geom:area_square_m":17875154165.711258,
+    "geom:area_square_m":17875155746.056164,
     "geom:bbox":"66.276407,33.90882,68.266523,35.483547",
     "geom:latitude":34.805986,
     "geom:longitude":67.232224,
@@ -373,6 +373,7 @@
         "gn:id":1147239,
         "gp:id":2344552,
         "hasc:id":"AF.BM",
+        "iso:code":"AF-BAM",
         "iso:id":"AF-BAM",
         "loc:id":"n2012029934",
         "qs_pg:id":898607,
@@ -380,11 +381,12 @@
         "wd:id":"Q171382",
         "wk:page":"Bamyan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a4aeac4bb37da0ba5d2bdf68d59e4c62",
+    "wof:geomhash":"e131342755db56cbf6c3c91744db5201",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -404,7 +406,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849234,
+    "wof:lastmodified":1695884477,
     "wof:name":"Bamian",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/05/85667505.geojson
+++ b/data/856/675/05/85667505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.690412,
-    "geom:area_square_m":16765464977.879686,
+    "geom:area_square_m":16765464050.842033,
     "geom:bbox":"66.253066,35.669505,68.205631,37.398494",
     "geom:latitude":36.66814,
     "geom:longitude":67.078223,
@@ -370,6 +370,7 @@
         "gn:id":1147288,
         "gp:id":2344575,
         "hasc:id":"AF.BK",
+        "iso:code":"AF-BAL",
         "iso:id":"AF-BAL",
         "loc:id":"n98034057",
         "qs_pg:id":241192,
@@ -377,11 +378,12 @@
         "wd:id":"Q121104",
         "wk:page":"Balkh Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f089587f719d3bfbd5ff832e90d37e80",
+    "wof:geomhash":"84146e8ecbe3ed8be7cdcc4c28a6cc18",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -401,7 +403,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849235,
+    "wof:lastmodified":1695884356,
     "wof:name":"Balkh",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/09/85667509.geojson
+++ b/data/856/675/09/85667509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.047475,
-    "geom:area_square_m":20465347446.020042,
+    "geom:area_square_m":20465347732.135616,
     "geom:bbox":"63.887745,35.163069,65.814702,37.250934",
     "geom:latitude":36.061614,
     "geom:longitude":64.875,
@@ -370,6 +370,7 @@
         "gn:id":1142226,
         "gp:id":2344554,
         "hasc:id":"AF.FB",
+        "iso:code":"AF-FYB",
         "iso:id":"AF-FYB",
         "loc:id":"n86066475",
         "qs_pg:id":984053,
@@ -377,11 +378,12 @@
         "wd:id":"Q173830",
         "wk:page":"Faryab Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"32de682473aa1342a38a20edd98b4176",
+    "wof:geomhash":"968e056d4e468a87fe3aa26c8866b409",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -401,7 +403,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849237,
+    "wof:lastmodified":1695884848,
     "wof:name":"Faryab",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/13/85667513.geojson
+++ b/data/856/675/13/85667513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.1404,
-    "geom:area_square_m":11287582008.125549,
+    "geom:area_square_m":11287582149.239574,
     "geom:bbox":"65.16,35.904955,66.575976,37.550763",
     "geom:latitude":36.823812,
     "geom:longitude":65.849992,
@@ -361,6 +361,7 @@
         "gn:id":1139049,
         "gp:id":2344576,
         "hasc:id":"AF.JW",
+        "iso:code":"AF-JOW",
         "iso:id":"AF-JOW",
         "loc:id":"n86066480",
         "qs_pg:id":1354562,
@@ -368,11 +369,12 @@
         "wd:id":"Q183036",
         "wk:page":"Jowzjan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c5dfd075551507b4be832be1c265e390",
+    "wof:geomhash":"3c253b500122954422dc9a7bf95e0e02",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -392,7 +394,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849241,
+    "wof:lastmodified":1695884477,
     "wof:name":"Jowzjan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/19/85667519.geojson
+++ b/data/856/675/19/85667519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.612441,
-    "geom:area_square_m":36951168669.458633,
+    "geom:area_square_m":36951167556.619629,
     "geom:bbox":"63.195479,33.122484,66.732421,35.283199",
     "geom:latitude":34.18124,
     "geom:longitude":64.930517,
@@ -357,6 +357,7 @@
         "gn:id":1141103,
         "gp:id":2344556,
         "hasc:id":"AF.GR",
+        "iso:code":"AF-GHO",
         "iso:id":"AF-GHO",
         "loc:id":"n86066476",
         "qs_pg:id":898609,
@@ -364,11 +365,12 @@
         "wd:id":"Q186392",
         "wk:page":"Ghor Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"67a0792c7d6b4ccfeb0af886e89dc576",
+    "wof:geomhash":"5a2a8ae3c4c2b5364e29ca339312e434",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -388,7 +390,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849236,
+    "wof:lastmodified":1695884477,
     "wof:name":"Ghowr",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/23/85667523.geojson
+++ b/data/856/675/23/85667523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.498309,
-    "geom:area_square_m":15043220833.235695,
+    "geom:area_square_m":15043221211.519962,
     "geom:bbox":"65.381215,34.869043,67.032027,36.564236",
     "geom:latitude":35.709575,
     "geom:longitude":66.143808,
@@ -346,15 +346,17 @@
         "gn:id":1127106,
         "gp:id":2344578,
         "hasc:id":"AF.SP",
+        "iso:code":"AF-SAR",
         "iso:id":"AF-SAR",
         "qs_pg:id":1134873,
         "wd:id":"Q182487"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"607aa9c79911f196c6ac517f282872ee",
+    "wof:geomhash":"2a4367c99d4450053fd53bdc5d01cb50",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -374,7 +376,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849240,
+    "wof:lastmodified":1695884477,
     "wof:name":"Sar-e Pol",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/27/85667527.geojson
+++ b/data/856/675/27/85667527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.7471,
-    "geom:area_square_m":49442276524.402237,
+    "geom:area_square_m":49442278377.939079,
     "geom:bbox":"60.583154,31.389555,64.748775,33.584412",
     "geom:latitude":32.612823,
     "geom:longitude":62.307327,
@@ -358,6 +358,7 @@
         "gn:id":1142263,
         "gp:id":2344553,
         "hasc:id":"AF.FH",
+        "iso:code":"AF-FRA",
         "iso:id":"AF-FRA",
         "loc:id":"n86066474",
         "qs_pg:id":318251,
@@ -365,11 +366,12 @@
         "wd:id":"Q180330",
         "wk:page":"Farah Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9682d066f34324e47293e05ca9d9307c",
+    "wof:geomhash":"5519683cbb30f3655fd78133f76f9de2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -389,7 +391,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849235,
+    "wof:lastmodified":1695884848,
     "wof:name":"Farah",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/31/85667531.geojson
+++ b/data/856/675/31/85667531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.491595,
-    "geom:area_square_m":58130650318.715309,
+    "geom:area_square_m":58130649521.859276,
     "geom:bbox":"62.549165,29.377217,65.376164,33.374513",
     "geom:latitude":31.106662,
     "geom:longitude":64.031692,
@@ -388,6 +388,7 @@
         "gn:id":1140043,
         "gp:id":2344557,
         "hasc:id":"AF.HM",
+        "iso:code":"AF-HEL",
         "iso:id":"AF-HEL",
         "loc:id":"n86066478",
         "nyt:id":"7252329074938834841",
@@ -396,11 +397,12 @@
         "wd:id":"Q173821",
         "wk:page":"Helmand Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"67dd0950ce1b164e952609324346137f",
+    "wof:geomhash":"138d572f870f67708bbda1ab5717d38d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -420,7 +422,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849237,
+    "wof:lastmodified":1695884849,
     "wof:name":"Helmand",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/37/85667537.geojson
+++ b/data/856/675/37/85667537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.900529,
-    "geom:area_square_m":41414078056.582138,
+    "geom:area_square_m":41414076885.424149,
     "geom:bbox":"60.872972,29.388695,63.591315,32.258528",
     "geom:latitude":30.825107,
     "geom:longitude":62.342179,
@@ -364,6 +364,7 @@
         "gn:id":1131821,
         "gp:id":2344565,
         "hasc:id":"AF.NM",
+        "iso:code":"AF-NIM",
         "iso:id":"AF-NIM",
         "loc:id":"n83039494",
         "qs_pg:id":44805,
@@ -371,11 +372,12 @@
         "wd:id":"Q183021",
         "wk:page":"Nimruz Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"abec69f6f4148c6271806b9edfabd59d",
+    "wof:geomhash":"811218660e3d877669bc9534f83066f2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -395,7 +397,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849238,
+    "wof:lastmodified":1695884478,
     "wof:name":"Nimruz",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/41/85667541.geojson
+++ b/data/856/675/41/85667541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.047973,
-    "geom:area_square_m":10885864707.715014,
+    "geom:area_square_m":10885865411.071106,
     "geom:bbox":"65.171737,32.270424,67.030418,33.329737",
     "geom:latitude":32.852591,
     "geom:longitude":66.057122,
@@ -388,17 +388,19 @@
         "gn:id":1131461,
         "gp:id":2344566,
         "hasc:id":"AF.OZ",
+        "iso:code":"AF-URU",
         "iso:id":"AF-URU",
         "loc:id":"n86066485",
         "qs_pg:id":1083779,
         "wd:id":"Q183028",
         "wk:page":"Urozgan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d1967ab9298d6aa77d9d145d795e7649",
+    "wof:geomhash":"9f5c77fe21b7704e49f7d6c585c79c99",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -418,7 +420,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849239,
+    "wof:lastmodified":1695884478,
     "wof:name":"Oruzgan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/49/85667549.geojson
+++ b/data/856/675/49/85667549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.101678,
-    "geom:area_square_m":54044181979.047874,
+    "geom:area_square_m":54044181830.861076,
     "geom:bbox":"64.504314,29.529583,67.79608,32.586586",
     "geom:latitude":31.042524,
     "geom:longitude":65.713039,
@@ -361,6 +361,7 @@
         "gn:id":1138335,
         "gp:id":2344569,
         "hasc:id":"AF.KD",
+        "iso:code":"AF-KAN",
         "iso:id":"AF-KAN",
         "loc:id":"n86066487",
         "qs_pg:id":423525,
@@ -368,11 +369,12 @@
         "wd:id":"Q173808",
         "wk:page":"Kandahar Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"568b72d809e60a9cbf37da5327c930b4",
+    "wof:geomhash":"79434a79f11d4b95ef55a96eca3f4886",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -392,7 +394,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849241,
+    "wof:lastmodified":1695884849,
     "wof:name":"Kandahar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/55/85667555.geojson
+++ b/data/856/675/55/85667555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.656155,
-    "geom:area_square_m":17328453297.366261,
+    "geom:area_square_m":17328453844.874672,
     "geom:bbox":"66.183804,31.496529,68.114261,33.078847",
     "geom:latitude":32.20075,
     "geom:longitude":67.148923,
@@ -374,6 +374,7 @@
         "gn:id":1121143,
         "gp:id":2344573,
         "hasc:id":"AF.ZB",
+        "iso:code":"AF-ZAB",
         "iso:id":"AF-ZAB",
         "loc:id":"no2013035694",
         "qs_pg:id":894839,
@@ -381,11 +382,12 @@
         "wd:id":"Q139126",
         "wk:page":"Zabul Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1f145fed0d6cae4ae183f46840a5508a",
+    "wof:geomhash":"4c305ff30865fd35ab966df4f849f3ac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -405,7 +407,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849238,
+    "wof:lastmodified":1695884849,
     "wof:name":"Zabol",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/61/85667561.geojson
+++ b/data/856/675/61/85667561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.106702,
-    "geom:area_square_m":21767629882.704449,
+    "geom:area_square_m":21767628847.995312,
     "geom:bbox":"66.820433,32.070387,68.827944,34.233287",
     "geom:latitude":33.31709,
     "geom:longitude":67.807215,
@@ -367,6 +367,7 @@
         "gn:id":1141268,
         "gp:id":2344555,
         "hasc:id":"AF.GZ",
+        "iso:code":"AF-GHA",
         "iso:id":"AF-GHA",
         "loc:id":"n96087882",
         "qs_pg:id":898608,
@@ -374,11 +375,12 @@
         "wd:id":"Q180415",
         "wk:page":"Ghazni Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"03bb65e31296646996a57a18fafd20f6",
+    "wof:geomhash":"33e6899b1b30588ab88d4677a32b57be",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -398,7 +400,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849233,
+    "wof:lastmodified":1695884847,
     "wof:name":"Ghazni",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/63/85667563.geojson
+++ b/data/856/675/63/85667563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.4155,
-    "geom:area_square_m":4290329920.758226,
+    "geom:area_square_m":4290329190.911459,
     "geom:bbox":"69.346721,33.018066,70.32848,33.73867",
     "geom:latitude":33.3774,
     "geom:longitude":69.833503,
@@ -367,17 +367,19 @@
         "gn:id":1444362,
         "gp:id":24550741,
         "hasc:id":"AF.KT",
+        "iso:code":"AF-KHO",
         "iso:id":"AF-KHO",
         "qs_pg:id":502949,
         "unlc:id":"AF-KHO",
         "wd:id":"Q185752",
         "wk:page":"Khost Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b4a0ccea2dd70d7b4fdb3079e5065210",
+    "wof:geomhash":"7daadd68d9d10c5dab14371c8378506e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -397,7 +399,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849239,
+    "wof:lastmodified":1695884478,
     "wof:name":"Khowst",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/67/85667567.geojson
+++ b/data/856/675/67/85667567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.830944,
-    "geom:area_square_m":19098692914.7985,
+    "geom:area_square_m":19098692718.44553,
     "geom:bbox":"67.809476,31.5934,69.5466,33.419793",
     "geom:latitude":32.477077,
     "geom:longitude":68.743506,
@@ -334,6 +334,7 @@
         "gn:id":1131256,
         "gp:id":2344574,
         "hasc:id":"AF.PK",
+        "iso:code":"AF-PKA",
         "iso:id":"AF-PKA",
         "loc:id":"n96087300",
         "qs_pg:id":894844,
@@ -341,11 +342,12 @@
         "wd:id":"Q185575",
         "wk:page":"Paktika Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1b5bcd3911d519be8ac5816734f6a905",
+    "wof:geomhash":"8ca2f7208ab3a95b7cd2382108aa6d63",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -365,7 +367,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849234,
+    "wof:lastmodified":1695884847,
     "wof:name":"Paktika",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/73/85667573.geojson
+++ b/data/856/675/73/85667573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.396987,
-    "geom:area_square_m":43397130678.661659,
+    "geom:area_square_m":43397129596.141655,
     "geom:bbox":"69.989018,35.440006,74.889862,38.490733",
     "geom:latitude":37.038023,
     "geom:longitude":71.456392,
@@ -388,6 +388,7 @@
         "gn:id":1147745,
         "gp:id":2344549,
         "hasc:id":"AF.BD",
+        "iso:code":"AF-BDS",
         "iso:id":"AF-BDS",
         "loc:id":"n83206283",
         "qs_pg:id":318249,
@@ -395,11 +396,12 @@
         "wd:id":"Q165376",
         "wk:page":"Badakhshan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"62edf3d133e91f01f37723cae835e5a8",
+    "wof:geomhash":"f64c2d4136cbdf83670e74fad02a1847",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -419,7 +421,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849236,
+    "wof:lastmodified":1695884848,
     "wof:name":"Badakhshan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/77/85667577.geojson
+++ b/data/856/675/77/85667577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.888741,
-    "geom:area_square_m":8955654247.389435,
+    "geom:area_square_m":8955653614.475874,
     "geom:bbox":"69.913287,34.904251,71.62143,36.03982",
     "geom:latitude":35.418771,
     "geom:longitude":70.789041,
@@ -379,17 +379,19 @@
         "gn:id":1444363,
         "gp:id":24549937,
         "hasc:id":"AF.NR",
+        "iso:code":"AF-NUR",
         "iso:id":"AF-NUR",
         "qs_pg:id":1164036,
         "unlc:id":"AF-NUR",
         "wd:id":"Q167485",
         "wk:page":"Nuristan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"33de25a77bfc4fc3e4915c50b5112fd7",
+    "wof:geomhash":"0b41d573213d96fe377ce34fce6b9048",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -409,7 +411,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849240,
+    "wof:lastmodified":1695884478,
     "wof:name":"Nurestan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/81/85667581.geojson
+++ b/data/856/675/81/85667581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.478682,
-    "geom:area_square_m":4850513754.02778,
+    "geom:area_square_m":4850513896.042373,
     "geom:bbox":"70.577602,34.523587,71.68137,35.482034",
     "geom:latitude":34.966475,
     "geom:longitude":71.094028,
@@ -361,6 +361,7 @@
         "gn:id":1135702,
         "gp:id":2344561,
         "hasc:id":"AF.KR",
+        "iso:code":"AF-KNR",
         "iso:id":"AF-KNR",
         "loc:id":"n89207637",
         "qs_pg:id":238660,
@@ -368,11 +369,12 @@
         "wd:id":"Q188147",
         "wk:page":"Kunar Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd2563844b7ea2f9716c111da4e7e361",
+    "wof:geomhash":"b441b98c50e1cfdc2c42d7016d597fcb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -392,7 +394,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849237,
+    "wof:lastmodified":1695884849,
     "wof:name":"Kunar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/85/85667585.geojson
+++ b/data/856/675/85/85667585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.803263,
-    "geom:area_square_m":7948847261.290778,
+    "geom:area_square_m":7948847453.191099,
     "geom:bbox":"68.025533,36.305175,69.34717,37.334596",
     "geom:latitude":36.842032,
     "geom:longitude":68.750214,
@@ -393,6 +393,7 @@
         "gn:id":1135690,
         "gp:id":2344570,
         "hasc:id":"AF.KZ",
+        "iso:code":"AF-KDZ",
         "iso:id":"AF-KDZ",
         "loc:id":"n87929913",
         "qs_pg:id":219490,
@@ -400,11 +401,12 @@
         "wd:id":"Q186418",
         "wk:page":"Kunduz Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"74d44ec3d769f9e7741b2e578ab3eb72",
+    "wof:geomhash":"d972d53bda278d66b6deeff4fe6b4cf9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -424,7 +426,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849240,
+    "wof:lastmodified":1695884478,
     "wof:name":"Konduz",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/91/85667591.geojson
+++ b/data/856/675/91/85667591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.720716,
-    "geom:area_square_m":7364270567.18343,
+    "geom:area_square_m":7364270858.59342,
     "geom:bbox":"69.478949,33.93978,71.17612,34.806378",
     "geom:latitude":34.27386,
     "geom:longitude":70.473948,
@@ -361,6 +361,7 @@
         "gn:id":1132366,
         "gp:id":2344564,
         "hasc:id":"AF.NG",
+        "iso:code":"AF-NAN",
         "iso:id":"AF-NAN",
         "loc:id":"n86066484",
         "qs_pg:id":1083778,
@@ -368,11 +369,12 @@
         "wd:id":"Q178471",
         "wk:page":"Nangarhar Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"57bb176851b47faa5db9e5155314d13f",
+    "wof:geomhash":"8f0f99d713e4b22452cbe1b1731e2123",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -392,7 +394,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849238,
+    "wof:lastmodified":1695884356,
     "wof:name":"Nangarhar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/675/95/85667595.geojson
+++ b/data/856/675/95/85667595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.241239,
-    "geom:area_square_m":12305253479.835169,
+    "geom:area_square_m":12305253533.660706,
     "geom:bbox":"69.174999,35.786735,70.503264,37.619925",
     "geom:latitude":36.700832,
     "geom:longitude":69.780256,
@@ -355,6 +355,7 @@
         "gn:id":1123230,
         "gp:id":2344571,
         "hasc:id":"AF.TK",
+        "iso:code":"AF-TAK",
         "iso:id":"AF-TAK",
         "loc:id":"n86066490",
         "qs_pg:id":219491,
@@ -362,11 +363,12 @@
         "wd:id":"Q186395",
         "wk:page":"Takhar Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"57ae361063b084229c773b30fb435a3c",
+    "wof:geomhash":"01ebf00ac4366e16fbd9530667f47b64",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -386,7 +388,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849234,
+    "wof:lastmodified":1695884848,
     "wof:name":"Takhar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/01/85667601.geojson
+++ b/data/856/676/01/85667601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.777234,
-    "geom:area_square_m":17822875310.441387,
+    "geom:area_square_m":17822875071.526272,
     "geom:bbox":"68.001452,35.003337,69.97096,36.576029",
     "geom:latitude":35.802594,
     "geom:longitude":68.912338,
@@ -358,6 +358,7 @@
         "gn:id":1147537,
         "gp:id":2344551,
         "hasc:id":"AF.BL",
+        "iso:code":"AF-BGL",
         "iso:id":"AF-BGL",
         "loc:id":"n2010053592",
         "qs_pg:id":318250,
@@ -365,11 +366,12 @@
         "wd:id":"Q170309",
         "wk:page":"Baghlan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d04d8e68c7e8f2f61b0df46fb0517eff",
+    "wof:geomhash":"4c720859389b311053c64c0c3d6f9d90",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -389,7 +391,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849246,
+    "wof:lastmodified":1695884850,
     "wof:name":"Baghlan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/03/85667603.geojson
+++ b/data/856/676/03/85667603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.451528,
-    "geom:area_square_m":4598199449.612049,
+    "geom:area_square_m":4598199640.428988,
     "geom:bbox":"68.833844,34.144004,69.947566,34.907841",
     "geom:latitude":34.55555,
     "geom:longitude":69.327878,
@@ -370,6 +370,7 @@
         "gn:id":1138957,
         "gp:id":2344559,
         "hasc:id":"AF.KB",
+        "iso:code":"AF-KAB",
         "iso:id":"AF-KAB",
         "loc:id":"n86066481",
         "qs_pg:id":238659,
@@ -377,11 +378,12 @@
         "wd:id":"Q188933",
         "wk:page":"Kabul Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"376330bb91175d4badfdd0b638d1111e",
+    "wof:geomhash":"4735cff4b43b52a617071f10208cad30",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -401,7 +403,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849244,
+    "wof:lastmodified":1695884849,
     "wof:name":"Kabul",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/09/85667609.geojson
+++ b/data/856/676/09/85667609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.18684,
-    "geom:area_square_m":1893344563.824354,
+    "geom:area_square_m":1893345005.64801,
     "geom:bbox":"69.272849,34.633721,69.928681,35.186329",
     "geom:latitude":34.963352,
     "geom:longitude":69.622227,
@@ -358,6 +358,7 @@
         "gn:id":1138255,
         "gp:id":2344560,
         "hasc:id":"AF.KP",
+        "iso:code":"AF-KAP",
         "iso:id":"AF-KAP",
         "loc:id":"n2005058615",
         "qs_pg:id":229356,
@@ -365,11 +366,12 @@
         "wd:id":"Q173816",
         "wk:page":"Kapisa Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"31d8faf558ef5845f70b6c08b0f2593a",
+    "wof:geomhash":"dc2b0a2e8798aa619f91021578bd9c21",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -389,7 +391,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849246,
+    "wof:lastmodified":1695884850,
     "wof:name":"Kapisa",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/17/85667617.geojson
+++ b/data/856/676/17/85667617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.387788,
-    "geom:area_square_m":3939337092.541223,
+    "geom:area_square_m":3939336984.501123,
     "geom:bbox":"69.806686,34.395449,70.634849,35.218227",
     "geom:latitude":34.760431,
     "geom:longitude":70.159197,
@@ -355,6 +355,7 @@
         "gn:id":1135022,
         "gp:id":2344562,
         "hasc:id":"AF.LA",
+        "iso:code":"AF-LAG",
         "iso:id":"AF-LAG",
         "loc:id":"n86066482",
         "qs_pg:id":1083777,
@@ -362,11 +363,12 @@
         "wd:id":"Q185442",
         "wk:page":"Laghman Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f405d1a7e9cfbf8971f0024e21a7bc6d",
+    "wof:geomhash":"4fd5a9652249aafc5d13a30a0fc65af4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -386,7 +388,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849245,
+    "wof:lastmodified":1695884850,
     "wof:name":"Laghman",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/23/85667623.geojson
+++ b/data/856/676/23/85667623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.429519,
-    "geom:area_square_m":4402362019.250435,
+    "geom:area_square_m":4402361917.106862,
     "geom:bbox":"68.714148,33.594167,69.885412,34.367837",
     "geom:latitude":34.013664,
     "geom:longitude":69.168135,
@@ -364,6 +364,7 @@
         "gn:id":1134561,
         "gp:id":2344563,
         "hasc:id":"AF.LW",
+        "iso:code":"AF-LOG",
         "iso:id":"AF-LOG",
         "loc:id":"n86066483",
         "qs_pg:id":984054,
@@ -371,11 +372,12 @@
         "wd:id":"Q6667298",
         "wk:page":"Logar Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8c306ed552768256170a8f72fbffc6ad",
+    "wof:geomhash":"4f7eeea4cfdc1dc4d8d09bfb0aaffce3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -395,7 +397,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849247,
+    "wof:lastmodified":1695884478,
     "wof:name":"Lowgar",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/27/85667627.geojson
+++ b/data/856/676/27/85667627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.549385,
-    "geom:area_square_m":5567546307.857023,
+    "geom:area_square_m":5567546253.15949,
     "geom:bbox":"68.187898,34.582656,69.613656,35.423308",
     "geom:latitude":34.95783,
     "geom:longitude":68.885313,
@@ -372,17 +372,19 @@
         "gn:id":6957555,
         "gp:id":56000467,
         "hasc:id":"AF.PV",
+        "iso:code":"AF-PAR",
         "iso:id":"AF-PAR",
         "loc:id":"n2012063624",
         "qs_pg:id":266216,
         "wd:id":"Q181235",
         "wk:page":"Panjshir Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d2182d90855566065ca41f171268e69",
+    "wof:geomhash":"11e4a5074e95f03d66d62f2127ff7bc5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -402,7 +404,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849245,
+    "wof:lastmodified":1695884850,
     "wof:name":"Parwan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/31/85667631.geojson
+++ b/data/856/676/31/85667631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.289888,
-    "geom:area_square_m":12907513922.260372,
+    "geom:area_square_m":12907514331.613398,
     "geom:bbox":"66.877722,35.344646,68.56777,36.64459",
     "geom:latitude":35.974791,
     "geom:longitude":67.703035,
@@ -352,6 +352,7 @@
         "gn:id":1127766,
         "gp:id":2344577,
         "hasc:id":"AF.SM",
+        "iso:code":"AF-SAM",
         "iso:id":"AF-SAM",
         "loc:id":"n86066489",
         "qs_pg:id":229357,
@@ -359,11 +360,12 @@
         "wd:id":"Q183015",
         "wk:page":"Samangan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a76528811b13847897f2375148c77023",
+    "wof:geomhash":"d8f29466508c93bc3dabecfdd6fd104b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -383,7 +385,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849246,
+    "wof:lastmodified":1695884850,
     "wof:name":"Samangan",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/35/85667635.geojson
+++ b/data/856/676/35/85667635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.038572,
-    "geom:area_square_m":10608317039.307405,
+    "geom:area_square_m":10608317668.869038,
     "geom:bbox":"67.216966,33.678797,68.9704,34.803576",
     "geom:latitude":34.303652,
     "geom:longitude":68.21707,
@@ -353,6 +353,7 @@
         "gn:id":1121863,
         "gp:id":2344572,
         "hasc:id":"AF.VR",
+        "iso:code":"AF-WAR",
         "iso:id":"AF-WAR",
         "loc:id":"n86066491",
         "qs_pg:id":318257,
@@ -360,11 +361,12 @@
         "wd:id":"Q183056",
         "wk:page":"Maidan Wardak Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"394a7b541a8178db3733b0912ea4567e",
+    "wof:geomhash":"464fa16b50bdf41d3f7d1d7396033afa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -384,7 +386,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849245,
+    "wof:lastmodified":1695884849,
     "wof:name":"Wardak",
     "wof:parent_id":85632229,
     "wof:placetype":"region",

--- a/data/856/676/41/85667641.geojson
+++ b/data/856/676/41/85667641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.513306,
-    "geom:area_square_m":5284643375.664299,
+    "geom:area_square_m":5284644821.898712,
     "geom:bbox":"68.76411,33.149136,70.00841,34.088072",
     "geom:latitude":33.632171,
     "geom:longitude":69.388239,
@@ -365,17 +365,19 @@
         "gn:id":1131257,
         "gp:id":2344567,
         "hasc:id":"AF.PT",
+        "iso:code":"AF-PIA",
         "iso:id":"AF-PIA",
         "loc:id":"n85302301",
         "qs_pg:id":1083780,
         "wd:id":"Q182493",
         "wk:page":"Paktia Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"17f7de85d6f92bd967d971b46b4dd319",
+    "wof:geomhash":"a9c3b53a380e8e57a532d52326ad4f35",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -395,7 +397,7 @@
         "tuk",
         "bal"
     ],
-    "wof:lastmodified":1690849247,
+    "wof:lastmodified":1695884478,
     "wof:name":"Paktia",
     "wof:parent_id":85632229,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.