### PR TITLE
[WIP] Deduplicate records, supersede, swap properties, concordances

### DIFF
--- a/data/120/966/095/9/1209660959.geojson
+++ b/data/120/966/095/9/1209660959.geojson
@@ -30,6 +30,11 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:und_x_variant":[
+        "Z\u012brak\u012b",
+        "\u0632\u06cc\u0631\u06a9\u06cc",
+        "Ziraki"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         85632229
@@ -37,6 +42,11 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1427368
+    },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1120592
+        ]
     },
     "wof:country":"AF",
     "wof:geomhash":"478c6a1064923547878b6e86323c3c60",
@@ -47,13 +57,15 @@
         }
     ],
     "wof:id":1209660959,
-    "wof:lastmodified":1566582810,
+    "wof:lastmodified":1706219585,
     "wof:name":"Ziraki",
     "wof:parent_id":85632229,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1310354551
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/122/579/608/7/1225796087.geojson
+++ b/data/122/579/608/7/1225796087.geojson
@@ -10,6 +10,7 @@
     "geom:latitude":33.02333,
     "geom:longitude":67.39583,
     "gn:admin1_code":"28",
+    "gn:admin2_code":"607",
     "gn:asciiname":"Sar-e Qadi",
     "gn:country_code":"AF",
     "gn:dem":2596,
@@ -29,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:und_x_variant":[
+        "Sar-e Q\u0101\u1e0fi",
+        "Sar-e Q\u0101\u1e95\u012b",
+        "Sar-e Q\u0101d\u012b",
+        "\u0633\u0631 \u0642\u0627\u062f\u06cc"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
@@ -39,6 +46,11 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1450718
+    },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1127101
+        ]
     },
     "wof:country":"AF",
     "wof:geomhash":"4e636a78f1585f5442badeb9bf224785",
@@ -52,13 +64,15 @@
         }
     ],
     "wof:id":1225796087,
-    "wof:lastmodified":1566584552,
+    "wof:lastmodified":1706219585,
     "wof:name":"Sar-e Qadi",
     "wof:parent_id":1108562091,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1310096027
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/122/655/380/3/1226553803.geojson
+++ b/data/122/655/380/3/1226553803.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:und_x_variant":[
+        "Sa\u1e5f\u0101w",
+        "Sar \u0100w",
+        "Sar \u0100b",
+        "\u0633\u0631 \u0622\u0628"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
@@ -41,8 +47,13 @@
     "wof:concordances":{
         "gn:id":1127438
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1127391
+        ]
+    },
     "wof:country":"AF",
-    "wof:geomhash":"220b230cab830ea6138009a58e837ca0",
+    "wof:geomhash":"c5cdc0fa5b40fd0a9a8e09ce3653cfac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -53,20 +64,22 @@
         }
     ],
     "wof:id":1226553803,
-    "wof:lastmodified":1566584471,
+    "wof:lastmodified":1706219585,
     "wof:name":"Sar Ab",
     "wof:parent_id":1108562591,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1276777365
+    ],
     "wof:tags":[]
 },
   "bbox": [
-    71.00471999999998,
+    71.00472,
     36.47417,
-    71.00471999999998,
+    71.00472,
     36.47417
 ],
-  "geometry": {"coordinates":[71.00471999999998,36.47417],"type":"Point"}
+  "geometry": {"coordinates":[71.00472000000001,36.47417],"type":"Point"}
 }

--- a/data/122/663/841/1/1226638411.geojson
+++ b/data/122/663/841/1/1226638411.geojson
@@ -45,6 +45,11 @@
     "wof:concordances":{
         "gn:id":1134882
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1444031
+        ]
+    },
     "wof:country":"AF",
     "wof:geomhash":"7749dbc185793d3c10d8e71ef714a5bf",
     "wof:hierarchy":[
@@ -57,13 +62,15 @@
         }
     ],
     "wof:id":1226638411,
-    "wof:lastmodified":1566584484,
+    "wof:lastmodified":1706219585,
     "wof:name":"Laman",
     "wof:parent_id":1108562047,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1343850469
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/122/673/086/3/1226730863.geojson
+++ b/data/122/673/086/3/1226730863.geojson
@@ -45,8 +45,13 @@
     "wof:concordances":{
         "gn:id":1394210
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1122042
+        ]
+    },
     "wof:country":"AF",
-    "wof:geomhash":"d47c4d41a6e57850549afa38155d9278",
+    "wof:geomhash":"d398f3ddf8e79b0c15d241d85faf2afd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -57,20 +62,22 @@
         }
     ],
     "wof:id":1226730863,
-    "wof:lastmodified":1566584254,
+    "wof:lastmodified":1706219585,
     "wof:name":"Tutachi",
     "wof:parent_id":1108562051,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1277165271
+    ],
     "wof:tags":[]
 },
   "bbox": [
-    61.92916999999999,
+    61.92917,
     35.00333,
-    61.92916999999999,
+    61.92917,
     35.00333
 ],
-  "geometry": {"coordinates":[61.92916999999999,35.00333],"type":"Point"}
+  "geometry": {"coordinates":[61.92917,35.00333],"type":"Point"}
 }

--- a/data/124/289/196/5/1242891965.geojson
+++ b/data/124/289/196/5/1242891965.geojson
@@ -12,6 +12,7 @@
     "gn:admin1_code":"19",
     "gn:admin2_code":"2202.0",
     "gn:asciiname":"Deh-e Now",
+    "gn:cc2":"AF",
     "gn:country_code":"AF",
     "gn:dem":478,
     "gn:feature_class":"P",
@@ -33,6 +34,10 @@
     "name:fas_x_preferred":[
         "\u062f\u0647 \u0646\u0648"
     ],
+    "name:und_x_variant":[
+        "\u1e0eehe Naw",
+        "Deh-e Now"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
@@ -43,6 +48,11 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":6651074
+    },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1143430
+        ]
     },
     "wof:country":"AF",
     "wof:geomhash":"454b6a3ecb5252ff3191a5a8c0a4d151",
@@ -56,13 +66,15 @@
         }
     ],
     "wof:id":1242891965,
-    "wof:lastmodified":1566583619,
+    "wof:lastmodified":1706219585,
     "wof:name":"Deh-e Now",
     "wof:parent_id":1108562129,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1326595397
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/124/325/316/1/1243253161.geojson
+++ b/data/124/325/316/1/1243253161.geojson
@@ -30,6 +30,11 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:und_x_variant":[
+        "Kham-e J\u0101r\u016bf\u012b",
+        "\u062e\u0645 \u062c\u0627\u0631\u0648\u0641\u06cc",
+        "Kham-e J\u0101\u1e5f\u016bfi"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
@@ -40,6 +45,11 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1474924
+    },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1137217
+        ]
     },
     "wof:country":"AF",
     "wof:geomhash":"dfc4d0dc33cc66cf7ff5fa9d95d4452d",
@@ -53,13 +63,15 @@
         }
     ],
     "wof:id":1243253161,
-    "wof:lastmodified":1566583743,
+    "wof:lastmodified":1706219586,
     "wof:name":"Kham-e Jarufi",
     "wof:parent_id":1108562549,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1276975779
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/125/957/274/9/1259572749.geojson
+++ b/data/125/957/274/9/1259572749.geojson
@@ -12,6 +12,7 @@
     "gn:admin1_code":"9",
     "gn:admin2_code":"2704.0",
     "gn:asciiname":"Tay Bil",
+    "gn:cc2":"AF",
     "gn:country_code":"AF",
     "gn:dem":1910,
     "gn:feature_class":"P",
@@ -30,6 +31,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:rus_x_preferred":[
+        "Taybil\u2019"
+    ],
+    "name:und_x_variant":[
+        "Tay B\u012bl"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
@@ -41,8 +48,13 @@
     "wof:concordances":{
         "gn:id":1448417
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1122615
+        ]
+    },
     "wof:country":"AF",
-    "wof:geomhash":"e70f84153198d3f58a587ebc94c9cab5",
+    "wof:geomhash":"356ca290afa17799b9a54b457941005b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -53,20 +65,22 @@
         }
     ],
     "wof:id":1259572749,
-    "wof:lastmodified":1566584071,
+    "wof:lastmodified":1706219586,
     "wof:name":"Tay Bil",
     "wof:parent_id":1108562423,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1309901631
+    ],
     "wof:tags":[]
 },
   "bbox": [
-    63.99916999999999,
+    63.99917,
     33.63556,
-    63.99916999999999,
+    63.99917,
     33.63556
 ],
-  "geometry": {"coordinates":[63.99916999999999,33.63556],"type":"Point"}
+  "geometry": {"coordinates":[63.99917,33.63556],"type":"Point"}
 }

--- a/data/125/988/382/1/1259883821.geojson
+++ b/data/125/988/382/1/1259883821.geojson
@@ -46,6 +46,11 @@
     "wof:concordances":{
         "gn:id":1467969
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1125934
+        ]
+    },
     "wof:country":"AF",
     "wof:geomhash":"d1738c06a6d388654a23e101c60ede7c",
     "wof:hierarchy":[
@@ -58,13 +63,15 @@
         }
     ],
     "wof:id":1259883821,
-    "wof:lastmodified":1566584161,
+    "wof:lastmodified":1706219586,
     "wof:name":"Shah Mari",
     "wof:parent_id":1108561821,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1293014549
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/125/998/367/1/1259983671.geojson
+++ b/data/125/998/367/1/1259983671.geojson
@@ -42,6 +42,12 @@
     "name:swe_x_preferred":[
         "Darkhan"
     ],
+    "name:und_x_variant":[
+        "\u1e0ea\u1e5fkh\u0101n",
+        "Da\u012bkhan",
+        "Darkh\u0101n",
+        "\u062f\u0631\u062e\u0627\u0646"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
@@ -52,6 +58,11 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1467968
+    },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1144299
+        ]
     },
     "wof:country":"AF",
     "wof:geomhash":"cc31cbfa734a99fbeff75eebcdbc94ca",
@@ -65,13 +76,15 @@
         }
     ],
     "wof:id":1259983671,
-    "wof:lastmodified":1566583969,
+    "wof:lastmodified":1706219586,
     "wof:name":"Darkhan",
     "wof:parent_id":1108561821,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1310705817
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/126/038/568/1/1260385681.geojson
+++ b/data/126/038/568/1/1260385681.geojson
@@ -45,6 +45,11 @@
     "wof:concordances":{
         "gn:id":1424375
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1424271
+        ]
+    },
     "wof:country":"AF",
     "wof:geomhash":"1f5c392c3c0817b8f1eac569d5816561",
     "wof:hierarchy":[
@@ -57,13 +62,15 @@
         }
     ],
     "wof:id":1260385681,
-    "wof:lastmodified":1566582987,
+    "wof:lastmodified":1706219586,
     "wof:name":"Sinjitak",
     "wof:parent_id":1108562397,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1276223943
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/127/622/394/3/1276223943.geojson
+++ b/data/127/622/394/3/1276223943.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"64.00028,35.6568,64.00028,35.6568",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:und_x_variant":[
         "\u0633\u0646\u062c\u062a\u06a9",
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1276223943,
-    "wof:lastmodified":1566582604,
+    "wof:lastmodified":1706219586,
     "wof:name":"Sinjitak",
     "wof:parent_id":1108562397,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1260385681
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/641/159/5/1276411595.geojson
+++ b/data/127/641/159/5/1276411595.geojson
@@ -30,6 +30,18 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:fas_x_preferred":[
+        "\u0642\u0644\u0639\u06c0 \u0641\u0631\u0647\u0627\u0686"
+    ],
+    "name:und_x_variant":[
+        "Kalayi-Farkhad",
+        "Qal\u0101-i-Fa\u1e5fh\u0101c",
+        "Qal\u0101-i-Fa\u1e5fh\u0101\u1e0f",
+        "Qal\u2018eh-ye Farh\u0101c",
+        "Qal\u2018eh-ye Fa\u1e5fh\u0101ts",
+        "\u0642\u0644\u0639\u06c0 \u0641\u0631\u0647\u0627\u062f",
+        "Qal\u2018ah-ye Farh\u0101d"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
@@ -41,8 +53,13 @@
     "wof:concordances":{
         "gn:id":7441796
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1130164
+        ]
+    },
     "wof:country":"AF",
-    "wof:geomhash":"ce9cc8473330f53d42de8aa5a0eba588",
+    "wof:geomhash":"b9dfd8a837593d658a26bff4dd596ff2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -53,20 +70,22 @@
         }
     ],
     "wof:id":1276411595,
-    "wof:lastmodified":1566582631,
+    "wof:lastmodified":1706219586,
     "wof:name":"Qal'ah-ye Farhad",
     "wof:parent_id":1108562117,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1309977631
+    ],
     "wof:tags":[]
 },
   "bbox": [
     69.14702,
-    34.79875999999999,
+    34.79876,
     69.14702,
-    34.79875999999999
+    34.79876
 ],
-  "geometry": {"coordinates":[69.14702,34.79875999999999],"type":"Point"}
+  "geometry": {"coordinates":[69.14702,34.79876],"type":"Point"}
 }

--- a/data/127/646/600/3/1276466003.geojson
+++ b/data/127/646/600/3/1276466003.geojson
@@ -46,8 +46,13 @@
     "wof:concordances":{
         "gn:id":1126251
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1444001
+        ]
+    },
     "wof:country":"AF",
-    "wof:geomhash":"e698c17401c96efd241bf49c9f71e02f",
+    "wof:geomhash":"bc2a0e5ebf624f0501089d7fcf646cdb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -58,20 +63,22 @@
         }
     ],
     "wof:id":1276466003,
-    "wof:lastmodified":1566582633,
+    "wof:lastmodified":1706219586,
     "wof:name":"Saydal",
     "wof:parent_id":1108562047,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1343754281
+    ],
     "wof:tags":[]
 },
   "bbox": [
     63.57516,
-    32.51309000000001,
+    32.51309,
     63.57516,
-    32.51309000000001
+    32.51309
 ],
-  "geometry": {"coordinates":[63.57516,32.51309000000001],"type":"Point"}
+  "geometry": {"coordinates":[63.57516,32.51309],"type":"Point"}
 }

--- a/data/127/677/736/5/1276777365.geojson
+++ b/data/127/677/736/5/1276777365.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"71.00393,36.47668,71.00393,36.47668",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:und_x_variant":[
         "Sa\u1e5f\u0101w",
@@ -48,7 +50,7 @@
         "gn:id":1127391
     },
     "wof:country":"AF",
-    "wof:geomhash":"f65373a4cb57227b3aab29a89b7d8cf2",
+    "wof:geomhash":"c5967e000e47688ebeb88dca2be15327",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -59,20 +61,22 @@
         }
     ],
     "wof:id":1276777365,
-    "wof:lastmodified":1566582644,
+    "wof:lastmodified":1706219585,
     "wof:name":"Sar Ab",
     "wof:parent_id":1108562591,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1226553803
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    71.00393000000003,
+    71.00393,
     36.47668,
-    71.00393000000003,
+    71.00393,
     36.47668
 ],
-  "geometry": {"coordinates":[71.00393000000003,36.47668],"type":"Point"}
+  "geometry": {"coordinates":[71.00393,36.47668],"type":"Point"}
 }

--- a/data/127/697/577/9/1276975779.geojson
+++ b/data/127/697/577/9/1276975779.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"63.59534,34.10755,63.59534,34.10755",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:und_x_variant":[
         "Kham-e J\u0101r\u016bf\u012b",
@@ -58,12 +60,14 @@
         }
     ],
     "wof:id":1276975779,
-    "wof:lastmodified":1566582654,
+    "wof:lastmodified":1706219585,
     "wof:name":"Kham-e Jarufi",
     "wof:parent_id":1108562549,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1243253161
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/716/527/1/1277165271.geojson
+++ b/data/127/716/527/1/1277165271.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"61.92682,35.00396,61.92682,35.00396",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:und_x_variant":[
         "T\u016btaci",
@@ -48,7 +50,7 @@
         "gn:id":1122042
     },
     "wof:country":"AF",
-    "wof:geomhash":"02cf8ae55bf4fc32976407d0cbbcfa41",
+    "wof:geomhash":"a5ea781ca740ef18864ec4f4733e6885",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -59,20 +61,22 @@
         }
     ],
     "wof:id":1277165271,
-    "wof:lastmodified":1566582682,
+    "wof:lastmodified":1706219585,
     "wof:name":"Tutachi",
     "wof:parent_id":1108562051,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1226730863
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    61.92681999999999,
+    61.92682,
     35.00396,
-    61.92681999999999,
+    61.92682,
     35.00396
 ],
-  "geometry": {"coordinates":[61.92681999999999,35.00396],"type":"Point"}
+  "geometry": {"coordinates":[61.92682,35.00396],"type":"Point"}
 }

--- a/data/129/301/454/9/1293014549.geojson
+++ b/data/129/301/454/9/1293014549.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"70.44954,37.01852,70.44954,37.01852",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:und_x_variant":[
         "S\u0304\u0101h M\u0101ri",
@@ -60,12 +62,14 @@
         }
     ],
     "wof:id":1293014549,
-    "wof:lastmodified":1566582272,
+    "wof:lastmodified":1706219586,
     "wof:name":"Shah Mari",
     "wof:parent_id":1108561821,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1259883821
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/335/180/3/1293351803.geojson
+++ b/data/129/335/180/3/1293351803.geojson
@@ -48,6 +48,11 @@
     "wof:concordances":{
         "gn:id":1443018
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            7475419
+        ]
+    },
     "wof:country":"AF",
     "wof:geomhash":"1c2a75c5d27c85cd353306bade62a5a4",
     "wof:hierarchy":[
@@ -60,13 +65,15 @@
         }
     ],
     "wof:id":1293351803,
-    "wof:lastmodified":1566582369,
+    "wof:lastmodified":1706219586,
     "wof:name":"Ghulam Sadiq Kala",
     "wof:parent_id":1108562309,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1343323353
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/130/977/158/5/1309771585.geojson
+++ b/data/130/977/158/5/1309771585.geojson
@@ -30,6 +30,18 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:fas_x_preferred":[
+        "Karam Sh\u0101h"
+    ],
+    "name:fas_x_variant":[
+        "\u06a9\u0631\u0645 \u0634\u0627\u0647",
+        "Karamsh\u0101h"
+    ],
+    "name:und_x_variant":[
+        "Karam",
+        "M\u0101kak\u012b",
+        "\u0645\u0627\u06a9\u06a9\u06cc"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
@@ -40,6 +52,11 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1436276
+    },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1113137
+        ]
     },
     "wof:country":"AF",
     "wof:geomhash":"b13c6933fdad558de78502db3d339c78",
@@ -53,13 +70,15 @@
         }
     ],
     "wof:id":1309771585,
-    "wof:lastmodified":1566583409,
+    "wof:lastmodified":1706219586,
     "wof:name":"Makaki",
     "wof:parent_id":1108562129,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1310270331
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/130/981/222/5/1309812225.geojson
+++ b/data/130/981/222/5/1309812225.geojson
@@ -12,6 +12,7 @@
     "gn:admin1_code":"2",
     "gn:admin2_code":"1907.0",
     "gn:asciiname":"Deh-e Babula'i",
+    "gn:cc2":"AF",
     "gn:country_code":"AF",
     "gn:dem":596,
     "gn:feature_class":"P",
@@ -51,6 +52,11 @@
         "gn:id":1147769,
         "wk:page":"Babula%27i"
     },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1400630
+        ]
+    },
     "wof:country":"AF",
     "wof:geomhash":"0add3bf4135acd9272524d41bd660c79",
     "wof:hierarchy":[
@@ -63,13 +69,15 @@
         }
     ],
     "wof:id":1309812225,
-    "wof:lastmodified":1566583500,
+    "wof:lastmodified":1706219586,
     "wof:name":"Deh-e Babula'i",
     "wof:parent_id":1108562287,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1343966653
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/130/990/163/1/1309901631.geojson
+++ b/data/130/990/163/1/1309901631.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"64.00028,33.63528,64.00028,33.63528",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:rus_x_preferred":[
         "Taybil\u2019"
@@ -60,12 +62,14 @@
         }
     ],
     "wof:id":1309901631,
-    "wof:lastmodified":1566583402,
+    "wof:lastmodified":1706219586,
     "wof:name":"Tay Bil",
     "wof:parent_id":1108562423,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1259572749
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/130/997/763/1/1309977631.geojson
+++ b/data/130/997/763/1/1309977631.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"69.14638,34.79846,69.14638,34.79846",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:fas_x_preferred":[
         "\u0642\u0644\u0639\u06c0 \u0641\u0631\u0647\u0627\u0686"
@@ -54,7 +56,7 @@
         "gn:id":1130164
     },
     "wof:country":"AF",
-    "wof:geomhash":"8b1071d758a6c7b719624c79db85cad9",
+    "wof:geomhash":"25b9d21e240589362d939a2ea844c448",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -65,20 +67,22 @@
         }
     ],
     "wof:id":1309977631,
-    "wof:lastmodified":1566583395,
+    "wof:lastmodified":1706219586,
     "wof:name":"Qal'ah-ye Farhad",
     "wof:parent_id":1108562117,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1276411595
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    69.14638000000001,
+    69.14638,
     34.79846,
-    69.14638000000001,
+    69.14638,
     34.79846
 ],
-  "geometry": {"coordinates":[69.14638000000001,34.79846],"type":"Point"}
+  "geometry": {"coordinates":[69.14637999999999,34.79846],"type":"Point"}
 }

--- a/data/131/009/602/7/1310096027.geojson
+++ b/data/131/009/602/7/1310096027.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"67.39724,33.02463,67.39724,33.02463",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:und_x_variant":[
         "Sar-e Q\u0101\u1e0fi",
@@ -59,12 +61,14 @@
         }
     ],
     "wof:id":1310096027,
-    "wof:lastmodified":1566583142,
+    "wof:lastmodified":1706219585,
     "wof:name":"Sar-e Qadi",
     "wof:parent_id":1108562091,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1225796087
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/027/033/1/1310270331.geojson
+++ b/data/131/027/033/1/1310270331.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"61.8138,31.1152,61.8138,31.1152",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:fas_x_preferred":[
         "Karam Sh\u0101h"
@@ -65,12 +67,14 @@
         }
     ],
     "wof:id":1310270331,
-    "wof:lastmodified":1566583181,
+    "wof:lastmodified":1706219586,
     "wof:name":"Makaki",
     "wof:parent_id":1108562129,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1309771585
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/035/455/1/1310354551.geojson
+++ b/data/131/035/455/1/1310354551.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"67.50289,35.96623,67.50289,35.96623",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:und_x_variant":[
         "Z\u012brak\u012b",
@@ -47,7 +49,7 @@
         "gn:id":1120592
     },
     "wof:country":"AF",
-    "wof:geomhash":"b89676a48d81d71f2566582a9643abc0",
+    "wof:geomhash":"bb3afa0ba4e4e1bd0f7309a4b02cde8c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -58,20 +60,22 @@
         }
     ],
     "wof:id":1310354551,
-    "wof:lastmodified":1566583210,
+    "wof:lastmodified":1706219585,
     "wof:name":"Ziraki",
     "wof:parent_id":1108561937,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1209660959
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    67.50289000000001,
+    67.50289,
     35.96623,
-    67.50289000000001,
+    67.50289,
     35.96623
 ],
-  "geometry": {"coordinates":[67.50289000000001,35.96623],"type":"Point"}
+  "geometry": {"coordinates":[67.50288999999999,35.96623],"type":"Point"}
 }

--- a/data/131/070/581/7/1310705817.geojson
+++ b/data/131/070/581/7/1310705817.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"70.45655,37.00125,70.45655,37.00125",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:ceb_x_preferred":[
         "Darkhan"
@@ -71,12 +73,14 @@
         }
     ],
     "wof:id":1310705817,
-    "wof:lastmodified":1566583106,
+    "wof:lastmodified":1706219586,
     "wof:name":"Darkhan",
     "wof:parent_id":1108561821,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1259983671
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/659/539/7/1326595397.geojson
+++ b/data/132/659/539/7/1326595397.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"61.79278,31.31361,61.79278,31.31361",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:und_x_variant":[
         "\u1e0eehe Naw",
@@ -47,7 +49,7 @@
         "gn:id":1143430
     },
     "wof:country":"AF",
-    "wof:geomhash":"b34e47423e8000654c2031b92f24a64a",
+    "wof:geomhash":"961bff25038dcf906d6161db75224e50",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -58,20 +60,22 @@
         }
     ],
     "wof:id":1326595397,
-    "wof:lastmodified":1566581722,
+    "wof:lastmodified":1706219585,
     "wof:name":"Deh-e Now",
     "wof:parent_id":1108562129,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1242891965
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    61.79278000000001,
+    61.79278,
     31.31361,
-    61.79278000000001,
+    61.79278,
     31.31361
 ],
-  "geometry": {"coordinates":[61.79278000000001,31.31361],"type":"Point"}
+  "geometry": {"coordinates":[61.79278,31.31361],"type":"Point"}
 }

--- a/data/134/332/335/3/1343323353.geojson
+++ b/data/134/332/335/3/1343323353.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"67.60785,32.31518,67.60785,32.31518",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:und_x_variant":[
         "Ghul\u0101m \u015ead\u012bq Kal\u0101",
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1343323353,
-    "wof:lastmodified":1566582127,
+    "wof:lastmodified":1706219586,
     "wof:name":"Ghulam Sadiq Kala",
     "wof:parent_id":1108562309,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1293351803
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/375/428/1/1343754281.geojson
+++ b/data/134/375/428/1/1343754281.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"63.57667,32.51389,63.57667,32.51389",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -42,7 +44,7 @@
         "gn:id":1444001
     },
     "wof:country":"AF",
-    "wof:geomhash":"80d63f09535c3f203915b4bd0db563a1",
+    "wof:geomhash":"3062e1f08b1e5cfb5e86f3528da2dc2a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -53,20 +55,22 @@
         }
     ],
     "wof:id":1343754281,
-    "wof:lastmodified":1566582203,
+    "wof:lastmodified":1706219586,
     "wof:name":"Saydal",
     "wof:parent_id":1108562047,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1276466003
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    63.57666999999999,
+    63.57667,
     32.51389,
-    63.57666999999999,
+    63.57667,
     32.51389
 ],
-  "geometry": {"coordinates":[63.57666999999999,32.51389],"type":"Point"}
+  "geometry": {"coordinates":[63.57667,32.51389],"type":"Point"}
 }

--- a/data/134/385/046/9/1343850469.geojson
+++ b/data/134/385/046/9/1343850469.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"63.51361,32.88194,63.51361,32.88194",
@@ -28,7 +30,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -53,12 +55,14 @@
         }
     ],
     "wof:id":1343850469,
-    "wof:lastmodified":1566582084,
+    "wof:lastmodified":1706219585,
     "wof:name":"Laman",
     "wof:parent_id":1108562047,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1226638411
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/396/665/3/1343966653.geojson
+++ b/data/134/396/665/3/1343966653.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"62.95083,35.31889,62.95083,35.31889",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:und_x_variant":[
         "\u1e0eeh-i-B\u0101b\u016bl\u0101'i"
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1343966653,
-    "wof:lastmodified":1566581968,
+    "wof:lastmodified":1706219586,
     "wof:name":"Deh-e Babula'i",
     "wof:parent_id":1108562287,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-af",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1309812225
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/859/029/81/85902981.geojson
+++ b/data/859/029/81/85902981.geojson
@@ -25,6 +25,7 @@
     "mz:is_official":0,
     "mz:max_zoom":18.0,
     "mz:min_zoom":13.0,
+    "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "mz:tier_locality":1,
     "name:eng_x_preferred":[
         "Chaman"
@@ -62,11 +63,30 @@
     "qs:woe_lau":0,
     "qs:woe_local":1922738,
     "qs:woe_ver":"7.10.0",
+    "qs_pg:name":"Chaman H\u0327o\u1e95\u016br\u012b",
+    "qs_pg:name_adm0":"Afghanistan",
+    "qs_pg:name_adm1":"Kabul",
+    "qs_pg:photos":666,
+    "qs_pg:photos_1k":135,
+    "qs_pg:photos_9k":3,
+    "qs_pg:photos_9r":5,
+    "qs_pg:photos_all":666,
+    "qs_pg:photos_sr":8,
+    "qs_pg:pop_sr":0,
+    "qs_pg:qs_id":1119342,
+    "qs_pg:qs_pg_placetype":"neighbourhood",
+    "qs_pg:qs_pg_placetype_gp":"Suburb",
+    "qs_pg:woe_adm0":23424739,
+    "qs_pg:woe_id":1918153,
     "src:geom":"mz",
     "src:geom_alt":[
         "quattroshapes"
     ],
     "src:lbl_centroid":"yerbashapes",
+    "woe:adm0_id":23424739,
+    "woe:name_adm0":"Afghanistan",
+    "woe:name_adm1":"Kabul",
+    "woe:placetype":"Suburb",
     "wof:belongsto":[
         85667603,
         102191569,
@@ -77,6 +97,14 @@
     "wof:concordances":{
         "gp:id":1918153,
         "qs_pg:id":1119342
+    },
+    "wof:concordances_alt":{
+        "gp:id":[
+            1918153
+        ],
+        "qs_pg:id":[
+            1119342
+        ]
     },
     "wof:country":"AF",
     "wof:geom_alt":[
@@ -97,13 +125,15 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1582326637,
+    "wof:lastmodified":1706219585,
     "wof:name":"Chaman H\u0327o\u1e95\u016br\u012b",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-af",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1126105865
+    ],
     "wof:tags":[]
 },
   "bbox": [


### PR DESCRIPTION
Round two... this PR updates duplicate records within WOF. When a duplicate pair/set is found:

- One record is superseded into the other
- Properties are transferred from the superseded record to the superseding record (if the property doesn't already exist)
- Concordances are transferred from the superseded record to the superseding record. If the concordance exists, a `wof:concordances_alt` property is used. If the concordance doesn't exist, it's added to the `wof:concordances` property

Duplicates were found by scoping a single placetype, checking for records with geometries near one another and identical (or nearly identical) names. Duplicate pairs were found the following way:

- If two point geometries: within 300m of one another
  - The older record of the two is kept, the newest is superseded
- If one point and one polygon: point is within the polygon OR point is within 300m of the polygon record's centroid
  - The record with the polygon is kept, the point is superseded
- If two polygon geometries: polygons overlap OR both records' centroids are within 300m of one another
  - The older record of the two is kept, the newest is superseded

Because this work is not scoped to a single repo, this work will also catch (many) cases where duplicates exist across two or more repos (one record in `whosonfirst-data-admin-xx` and `whosonfirst-data-admin-cr`, for example). I'm sure there are some edge cases that won't be caught with these parameters, but the duplicates I've reviewed have been legitimate. No PIP work needed - once this is approved, I'll open a few more PRs for review before running against all admin repos.